### PR TITLE
Fix Anemoi qa

### DIFF
--- a/sync-files/anemoi/some/.github/workflows/push-to-private.yml
+++ b/sync-files/anemoi/some/.github/workflows/push-to-private.yml
@@ -32,4 +32,3 @@ jobs:
       run: |
         git remote add private git@github.com:{% raw %}${{ github.repository }}{% endraw %}-private.git
         git push --set-upstream private main
-


### PR DESCRIPTION
One of the sync file is failing pre-commit hooks in the receiving repo due to an extra line at the end. This removes the line. 