### PR TITLE
add precommit config to core in anemoi sync

### DIFF
--- a/sync-files/sync.yml
+++ b/sync-files/sync.yml
@@ -219,5 +219,7 @@ group:
     dest: .github/workflows/pr-conventional-commit.yml
     template:
       repo_name: anemoi-core
+  - source: sync-files/anemoi/all/.pre-commit-config.yaml
+    dest: .pre-commit-config.yaml
   repos: |
     ecmwf/anemoi-core


### PR DESCRIPTION
Adds the precommit config file to the list of files to be synced to anemoi-core (in the sync config). It was previously not updated by the sync.