### PR TITLE
PyWheelWrap: fix venvs

### DIFF
--- a/.github/workflows/python-wrapper-wheel.yml
+++ b/.github/workflows/python-wrapper-wheel.yml
@@ -44,10 +44,15 @@ jobs:
       - run: cd /src/proj && if [[ -f ./${{ inputs.wheel_directory }}/pre-compile.sh ]] ; then ./${{ inputs.wheel_directory }}/pre-compile.sh ; fi
       - run: cd /src/proj && /buildscripts/compile.sh ./${{ inputs.wheel_directory }}/buildconfig
       - run: cd /src/proj && if [[ -f ./${{ inputs.wheel_directory }}/post-compile.sh ]] ; then ./${{ inputs.wheel_directory }}/post-compile.sh ; fi
-      - run: cd /src/proj && GITHUB_BRANCH="${GITHUB_REF}" PYTHONPATH=/buildscripts /buildscripts/wheel-linux.sh ./${{ inputs.wheel_directory }}/buildconfig "${{ matrix.python_version }}"
-      - run: cd /src/proj && if [[ -f ./${{ inputs.wheel_directory }}/post-build.sh ]] ; then ./${{ inputs.wheel_directory }}/post-build.sh ; fi
-      - run: cd /src/proj && GITHUB_BRANCH="${GITHUB_REF}" /buildscripts/test-wheel.sh ./${{ inputs.wheel_directory }}/buildconfig "${{ matrix.python_version }}"
-      - run: cd /src/proj && PYTHONPATH=/buildscripts /buildscripts/upload-pypi.sh ./${{ inputs.wheel_directory }}/buildconfig
+      - run: |
+          # TODO move this to the dockerfile, but needs to be done per python version
+          # NOTE twine version forced due to metadata issue, cf wheelmaker Dockerfile
+          rm -rf /tmp/buildvenv && uv venv --python python"${{ matrix.python_version }}" /tmp/buildvenv && source /tmp/buildvenv/bin/activate && uv pip install build twine==6.0.1 delocate setuptools requests
+          cd /src/proj
+          GITHUB_BRANCH="${GITHUB_REF}" PYTHONPATH=/buildscripts /buildscripts/wheel-linux.sh ./${{ inputs.wheel_directory }}/buildconfig
+          if [[ -f ./${{ inputs.wheel_directory }}/post-build.sh ]] ; then ./${{ inputs.wheel_directory }}/post-build.sh ; fi
+          GITHUB_BRANCH="${GITHUB_REF}" /buildscripts/test-wheel.sh ./${{ inputs.wheel_directory }}/buildconfig "${{ matrix.python_version }}"
+          PYTHONPATH=/buildscripts /buildscripts/upload-pypi.sh ./${{ inputs.wheel_directory }}/buildconfig
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Changes to the wheelmaker image/repo -- due to how `uv` behaves in the presence of an unrelated `pyproject.toml` anywhere among the parent directories, we need to be more explicit with venvs during the wheelmaking

Tested on metkit wheel building https://github.com/ecmwf/metkit/actions/runs/14125779033