### PR TITLE
Feat/build multiple wheels

### DIFF
--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install twine setuptools wheel cibuildwheel
+          pip install twine setuptools wheel cibuildwheel setuptools-rust
 
       - name: Check version
         shell: python

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ''
+      env_vars:
+        description: A way to set env variables
+        type: string
+        required: false
+        default: ''
 
 
 jobs:
@@ -40,6 +45,15 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
+      - name: Set env variables from input
+        if: inputs.env_vars != ''
+        run: |
+          for key in $(echo '${{ inputs.env_vars }}' | jq -r 'keys[]'); do
+            value=$(echo '${{ inputs.env_vars }}' | jq -r ".\"$key\"")
+            echo "$key=$value" >> $GITHUB_ENV
+          done
+        shell: bash
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel cibuildwheel
+          pip install twine setuptools wheel cibuildwheel
 
       - name: Build wheels
         run: |

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -34,7 +34,7 @@ on:
 
 
 jobs:
-  build:
+  deploy:
     if:  inputs.platforms != '' && inputs.pyversions != ''
     strategy:
       matrix:
@@ -74,28 +74,6 @@ jobs:
         env:
           CIBW_BUILD: "cp${{ matrix.python }}-*"
           CIBW_BUILD_VERBOSITY: 1
-      
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.platform }}-${{ matrix.python }}
-          path: dist/*.whl
-
-  upload:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: all-wheels
-
-      - run: |
-          mkdir dist
-          find all-wheels -name "*.whl" -exec cp {} dist/ \;
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install twine
 
       - name: Upload to PyPI
         if: ${{ !inputs.testpypi }}

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   deploy:
-    if:  inputs.platforms != '' && inputs.pyversions != ''
+    if:  {{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || (inputs.platforms != '' && inputs.pyversions != '') }}
     strategy:
       matrix:
         platform: ${{ fromJson(inputs.platforms) }}
@@ -62,11 +62,57 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+      
+      - name: Test tag name pattern
+        if: ${{ !inputs.testpypi }}
+        shell: python
+        run: |
+          import re
+          import sys
+
+          tag_pattern = r"${{ vars.TAG_REGEX_FOR_DEPLOYMENT }}"
+          ref = "${{ github.ref_name }}"
+
+          if not tag_pattern:
+            sys.exit(0)
+
+          if not re.match(tag_pattern, ref):
+            print(f"::error::{ref} does not match {tag_pattern}")
+            sys.exit(1)
+
+      - name: Test branch name pattern
+        if: ${{ vars.BRANCH_REGEX_FOR_DEPLOYMENT != '' && !inputs.testpypi }}
+        run: |
+          echo "Checking that this release is being made from a main/master branch ( ${{ vars.BRANCH_REGEX_FOR_DEPLOYMENT }} ) - will fail if not"
+          git branch --all --list --format "%(refname:lstrip=-1)" --contains "${{ github.ref_name }}" | grep -E "${{ vars.BRANCH_REGEX_FOR_DEPLOYMENT }}"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install twine setuptools wheel cibuildwheel
+
+      - name: Check version
+        shell: python
+        run: |
+          import os
+          import subprocess
+          import tomllib
+          from pathlib import Path
+
+          if Path("setup.py").is_file():
+              if Path("pyproject.toml").is_file():
+                  with open("pyproject.toml", "rb") as f:
+                      data = tomllib.load(f)
+                  requires = data["build-system"]["requires"]
+                  subprocess.run(["pip", "install", "--upgrade", *requires], check=True)
+
+              result = subprocess.run(["python", "setup.py", "--version"], capture_output=True, text=True, check=True)
+              version = result.stdout.strip()
+              release = os.environ.get("GITHUB_REF_NAME")
+              testpypi = os.environ.get("INPUT_TESTPYPI", "").lower() == "true"
+
+              if not testpypi and release != version:
+                  raise SystemExit(f"Version mismatch: release '{release}' != setup.py version '{version}'")
 
       - name: Build wheels
         run: |

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -1,0 +1,100 @@
+---
+name: cd-pypi
+
+on:
+  workflow_call:
+    inputs:
+      testpypi:
+        description: Whether to upload to testpypi instead of pypi.
+          Requires secrets.PYPI_TEST_API_TOKEN to be defined.
+        type: boolean
+        required: false
+        default: false
+      working-directory:
+        description: Working directory to build Python package (for monorepos).
+          Defaults to root directory.
+        type: string
+        required: false
+        default: "./"
+      platforms:
+        description: For not pure python project, the platforms to build for e.g. "['ubuntu-latest','macos-latest','windows-latest']"
+        required: false
+        type: string
+        default: ''
+      pyversions:
+        description: For not pure python project, the Python versions to build for e.g. "['38','39','310','311','312','313']"
+        required: false
+        type: string
+        default: ''
+
+
+jobs:
+  build:
+    if:  inputs.platforms != '' && inputs.pyversions != ''
+    strategy:
+      matrix:
+        platform: ${{ fromJson(inputs.platforms) }}
+        python: ${{ fromJson(inputs.pyversions) }}
+    runs-on: ${{ matrix.platform }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine build cibuildwheel
+
+      - name: Build wheels
+        run: |
+          cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp${{ matrix.python }}-*"
+          CIBW_BUILD_VERBOSITY: 1
+      
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform }}-${{ matrix.python }}
+          path: dist/*.whl
+
+  upload:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: all-wheels
+
+      - run: |
+          mkdir dist
+          find all-wheels -name "*.whl" -exec cp {} dist/ \;
+
+      - name: Upload to PyPI
+        if: ${{ !inputs.testpypi }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine check dist/*.whl
+          twine upload dist/*.whl
+
+      - name: Upload to test-PyPI
+        if: ${{ inputs.testpypi }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
+        run: |
+          twine check dist/*.whl
+          # HINT: if your upload fails here due to "unsupported local version",
+          # put `local_scheme = "no-local-version"` pyproject.toml's
+          # [tools.setuptools_scm]
+          twine upload --repository testpypi --verbose dist/*.whl

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -109,7 +109,9 @@ jobs:
               result = subprocess.run(["python", "setup.py", "--version"], capture_output=True, text=True, check=True)
               version = result.stdout.strip()
               release = os.environ.get("GITHUB_REF_NAME")
-              testpypi = os.environ.get("INPUT_TESTPYPI", "").lower() == "true"
+              testpypi = os.environ.get("INPUT_TESTPYPI").lower() == "true"
+
+              print(version, release, testpypi)
 
               if not testpypi and release != version:
                   raise SystemExit(f"Version mismatch: release '{release}' != setup.py version '{version}'")

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -113,8 +113,6 @@ jobs:
               release = os.environ.get("GITHUB_REF_NAME")
               testpypi = os.environ.get("INPUT_TESTPYPI").lower() == "true"
 
-              print(version, release, testpypi)
-
               if not testpypi and release != version:
                   raise SystemExit(f"Version mismatch: release '{release}' != setup.py version '{version}'")
 

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -1,5 +1,5 @@
 ---
-name: cd-pypi
+name: cd-pypi-binwheel
 
 on:
   workflow_call:

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   deploy:
-    if:  {{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || (inputs.platforms != '' && inputs.pyversions != '') }}
+    if:  ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || (inputs.platforms != '' && inputs.pyversions != '') }}
     strategy:
       matrix:
         platform: ${{ fromJson(inputs.platforms) }}

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine build cibuildwheel
+          pip install setuptools wheel cibuildwheel
 
       - name: Build wheels
         run: |
@@ -91,6 +91,11 @@ jobs:
       - run: |
           mkdir dist
           find all-wheels -name "*.whl" -exec cp {} dist/ \;
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
 
       - name: Upload to PyPI
         if: ${{ !inputs.testpypi }}

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Check version
         shell: python
+        env:
+          INPUT_TESTPYPI: ${{ inputs.testpypi }}
         run: |
           import os
           import subprocess

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -25,7 +25,7 @@ on:
         description: Python versions to build for.
         required: false
         type: string
-        default: "['3.8', '3.9', '3.10']"
+        default: "['38', '39', '310']"
 
 jobs:
   build:
@@ -43,7 +43,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
-          python-version: ${{ matrix.python }}
 
       - name: Test tag name pattern
         if: ${{ !inputs.testpypi }}

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -20,12 +20,12 @@ on:
         description: Platforms to build for e.g. "['ubuntu-latest','macos-latest','windows-latest']"
         required: false
         type: string
-        default: ''
+        default: "['invalid']" #hacky workaround to get things to run
       pyversions:
         description: Python versions to build for e.g. "['38','39','310','311','312']"
         required: false
         type: string
-        default: ''
+        default: "['invalid']" #hacky workaround to get things to run
       build_args:
         description: Args to pass in to build as `python -m build {build_args}` e.g. '--sdist'
         type: string
@@ -116,11 +116,13 @@ jobs:
 
 
   deploy_wheels:
-    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms!='' || inputs.pyversions!='' }}
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms!="['invalid']" || inputs.pyversions!="['invalid']" }}
     needs: deploy_source
     name: Build wheels and source distribution
     strategy:
-      matrix: ${{ fromJson(format('{{"os": {0}, "python": {1}}}', (inputs.platforms != null && inputs.platforms != '' && inputs.platforms != '[]') && inputs.platforms || '["ubuntu-latest"]', (inputs.pyversions != null && inputs.pyversions != '' && inputs.pyversions != '[]') && inputs.pyversions || '["3.11"]' )) }}
+      matrix:
+        os: ${{ fromJson(inputs.platforms) }}
+        python: ${{ fromJson(inputs.pyversions) }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -72,11 +72,6 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine build cibuildwheel
-
       - name: Check version
         run: |
           if [ -f "setup.py" ]; then
@@ -95,6 +90,11 @@ jobs:
           cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: "cp${{ matrix.python }}-*"
+          CIBW_SKIP: "pp*"
+          CIBW_BEFORE_BUILD: |
+            python -m pip install --upgrade pip
+            pip install setuptools wheel twine build cibuildwheel
+          CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -82,10 +82,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools wheel twine build cibuildwheel
 
-      - name: Install rust
-        run: |
-          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-          . "$HOME/.cargo/env"
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Check version
         run: |

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -110,7 +110,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
+          name: wheels-${{ matrix.python }}-${{ matrix.os }}
           path: dist/*.whl
 
   upload:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -103,7 +103,6 @@ jobs:
           path: dist
 
   upload:
-    if: ${{ inputs.upload }}
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -22,6 +22,11 @@ on:
         type: string
         required: false
         default: ''
+      env_vars:
+        description: A way to set env variables
+        type: string
+        required: false
+        default: ''
 
 
 jobs:
@@ -32,6 +37,15 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
+      - name: Set env variables from input
+        if: inputs.env_vars != ''
+        run: |
+          for key in $(echo '${{ inputs.env_vars }}' | jq -r 'keys[]'); do
+            value=$(echo '${{ inputs.env_vars }}' | jq -r ".\"$key\"")
+            echo "$key=$value" >> $GITHUB_ENV
+          done
+        shell: bash
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
-          path: dist
+          path: dist/*.whl
 
   upload:
     needs: build
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: wheels-*
-          path: dist
+          path: dist/*
 
       - name: Upload to PyPI
         if: ${{ !inputs.testpypi }}

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -82,26 +82,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools wheel twine build cibuildwheel
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      
-      - name: Check if rust is installed
-        run: |
-          rustc --version
-
-      - name: Check version
-        run: |
-          if [ -f "setup.py" ]; then
-            if [ -f "pyproject.toml" ] ; then
-              # we need to install eg setuptools_scm to correctly determine version later
-              extra_deps=$(python -c 'import tomllib; print(" ".join(f"{e}" for e in tomllib.load(open("pyproject.toml", "rb"))["build-system"]["requires"]))')
-              pip install --upgrade $extra_deps
-            fi
-            version=$(python setup.py --version)
-            release=${{ github.ref_name }}
-            if [ "${{ inputs.testpypi }}" != "true" ] ; then test "$release" == "$version"; fi
-          fi
+      # - name: Check version
+      #   run: |
+      #     if [ -f "setup.py" ]; then
+      #       if [ -f "pyproject.toml" ] ; then
+      #         # we need to install eg setuptools_scm to correctly determine version later
+      #         extra_deps=$(python -c 'import tomllib; print(" ".join(f"{e}" for e in tomllib.load(open("pyproject.toml", "rb"))["build-system"]["requires"]))')
+      #         pip install --upgrade $extra_deps
+      #       fi
+      #       version=$(python setup.py --version)
+      #       release=${{ github.ref_name }}
+      #       if [ "${{ inputs.testpypi }}" != "true" ] ; then test "$release" == "$version"; fi
+      #     fi
 
       - name: Build wheels
         run: |

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -17,7 +17,7 @@ on:
         required: false
         default: "./"
       buildargs:
-        description: Args to pass in to build as `python -m build {purepython_buildargs}`
+        description: Args to pass in to build as `python -m build {buildargs}`
           e.g. '--sdist' for just source distribution
         type: string
         required: false
@@ -102,7 +102,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python -m build ${{ inputs.purepython_buildargs }}
+          python -m build ${{ inputs.buildargs }}
           twine check dist/*
           twine upload dist/*
 
@@ -112,7 +112,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
         run: |
-          python -m build ${{ inputs.purepython_buildargs }}
+          python -m build ${{ inputs.buildargs }}
           twine check dist/*
           # HINT: if your upload fails here due to "unsupported local version",
           # put `local_scheme = "no-local-version"` pyproject.toml's

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -85,6 +85,10 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      
+      - name: Check if rust is installed
+        run: |
+          rustc --version
 
       - name: Check version
         run: |
@@ -106,10 +110,7 @@ jobs:
           CIBW_BUILD: "cp${{ matrix.python }}-*"
           CIBW_SKIP: "pp*"
           CIBW_BEFORE_BUILD: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-            . "$HOME/.cargo/env"
-            python -m pip install --upgrade pip
-            pip install setuptools wheel twine build cibuildwheel
+            rustc --version
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -116,7 +116,7 @@ jobs:
 
 
   deploy_wheels:
-    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms!="['invalid']" || inputs.pyversions!="['invalid']" }}
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms!=\"['invalid']\" || inputs.pyversions!=\"['invalid']\" }}
     needs: deploy_source
     name: Build wheels and source distribution
     strategy:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -110,7 +110,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
           path: dist
 
   upload:
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          name: wheels-*
           path: dist
 
       - name: Upload to PyPI

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -20,12 +20,12 @@ on:
         description: 'Comma-separated list of platforms to build for (e.g., ubuntu-latest,windows-latest). Default: "ubuntu-latest".'
         required: false
         type: string
-        default: 'ubuntu-latest'
+        default: '[ubuntu-latest]'
       python_versions:
         description: 'Comma-separated list of Python versions to build for (e.g., 3.8, 3.9, 3.10). Default: "3.8, 3.9, 3.10".'
         required: false
         type: string
-        default: '3.8,3.9,3.10'
+        default: '[3.8,3.9,3.10]'
 
 jobs:
   build:
@@ -33,8 +33,8 @@ jobs:
     name: Build wheels and source distribution
     strategy:
       matrix:
-        os: ${{ fromJson('[' + inputs.platforms + ']') }}  # Convert comma-separated string into an array
-        python: ${{ fromJson('[' + inputs.python_versions + ']') }}  # Convert comma-separated string into an array
+        os: ${{ fromJson(inputs.platforms) }}  # Convert comma-separated string into an array
+        python: ${{ fromJson(inputs.python_versions) }}  # Convert comma-separated string into an array
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: "['38', '39', '310']"
+      rust: # TODO: use this
+        description: Whether to install rust
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build:
@@ -97,6 +102,8 @@ jobs:
           CIBW_BUILD: "cp${{ matrix.python }}-*"
           CIBW_SKIP: "pp*"
           CIBW_BEFORE_BUILD: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+            . "$HOME/.cargo/env"
             python -m pip install --upgrade pip
             pip install setuptools wheel twine build cibuildwheel
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -121,8 +121,8 @@ jobs:
     name: Build wheels and source distribution
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.platforms) }}
-        python: ${{ fromJson(inputs.pyversions) }}
+        os: ${{ fromJson(inputs.platforms) || ['ubuntu-latest'] }}
+        python: ${{ fromJson(inputs.pyversions) || ['310'] }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -25,7 +25,7 @@ on:
         description: 'Comma-separated list of Python versions to build for (e.g., 3.8, 3.9, 3.10). Default: "3.8, 3.9, 3.10".'
         required: false
         type: string
-        default: '3.8, 3.9, 3.10'
+        default: '3.8,3.9,3.10'
 
 jobs:
   build:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -110,7 +110,8 @@ jobs:
           CIBW_BUILD: "cp${{ matrix.python }}-*"
           CIBW_SKIP: "pp*"
           CIBW_BEFORE_BUILD: |
-            rustc --version
+            source $HOME/.cargo/env  # Explicitly source Rust environment
+            rustc --version  # Check if rustc is available
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -121,8 +121,8 @@ jobs:
     name: Build wheels and source distribution
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.platforms) || ['ubuntu-latest'] }}
-        python: ${{ fromJson(inputs.pyversions) || ['310'] }}
+        os: ${{ fromJson(inputs.platforms != '' ? inputs.platforms : '["ubuntu-latest"]') }}
+        python: ${{ fromJson(inputs.platforms != '' ? inputs.platforms : '["310"]') }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -33,7 +33,7 @@ on:
         default: false
 
 jobs:
-  build:
+  deploy:
     if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi }}
     name: Build wheels and source distribution
     strategy:
@@ -110,20 +110,6 @@ jobs:
           CIBW_BUILD: "cp${{ matrix.python }}-*"
           CIBW_BUILD_VERBOSITY: 1
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.python }}-${{ matrix.os }}
-          path: dist/*.whl
-
-  upload:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: wheels-*
-          path: dist/*
-
       - name: Upload to PyPI
         if: ${{ !inputs.testpypi }}
         env:
@@ -131,8 +117,8 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           pip install twine
-          twine check dist/*
-          twine upload dist/*
+          twine check dist/*.whl
+          twine upload dist/*.whl
 
       - name: Upload to test-PyPI
         if: ${{ inputs.testpypi }}
@@ -141,8 +127,8 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
         run: |
           pip install twine
-          twine check dist/*
+          twine check dist/*.whl
           # HINT: if your upload fails here due to "unsupported local version",
           # put `local_scheme = "no-local-version"` pyproject.toml's
           # [tools.setuptools_scm]
-          twine upload --repository testpypi --verbose dist/*
+          twine upload --repository testpypi --verbose dist/*.whl

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -17,15 +17,15 @@ on:
         required: false
         default: "./"
       platforms:
-        description: 'Comma-separated list of platforms to build for (e.g., ubuntu-latest,windows-latest). Default: "ubuntu-latest".'
+        description: Platforms to build for.
         required: false
         type: string
-        default: '[ubuntu-latest]'
-      python_versions:
-        description: 'Comma-separated list of Python versions to build for (e.g., 3.8, 3.9, 3.10). Default: "3.8, 3.9, 3.10".'
+        default: "['ubuntu-latest']"
+      pyversions:
+        description: Python versions to build for.
         required: false
         type: string
-        default: '[3.8,3.9,3.10]'
+        default: "['3.8', '3.9', '3.10']"
 
 jobs:
   build:
@@ -33,8 +33,8 @@ jobs:
     name: Build wheels and source distribution
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.platforms) }}  # Convert comma-separated string into an array
-        python: ${{ fromJson(inputs.python_versions) }}  # Convert comma-separated string into an array
+        os: ${{ fromJson(inputs.platforms) }}
+        python: ${{ fromJson(inputs.pyversions) }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -20,12 +20,12 @@ on:
         description: Platforms to build for e.g. "['ubuntu-latest','macos-latest','windows-latest']"
         required: false
         type: string
-        default: "invalid" #hacky workaround to get things to run
+        default: ''
       pyversions:
         description: Python versions to build for e.g. "['38','39','310','311','312']"
         required: false
         type: string
-        default: "invalid" #hacky workaround to get things to run
+        default: ''
       build_args:
         description: Args to pass in to build as `python -m build {build_args}` e.g. '--sdist'
         type: string
@@ -116,13 +116,13 @@ jobs:
 
 
   deploy_wheels:
-    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms != "invalid" || inputs.pyversions != "invalid" }}
+    if:  {{ inputs.platforms != '' && inputs.pyversions != '' }}
     needs: deploy_source
     name: Build wheels and source distribution
     strategy:
       matrix:
-        os: ${{ inputs.platforms != '' && inputs.platforms != 'invalid' ? fromJson(inputs.platforms) : ['skip'] }}
-        python: ${{ inputs.pyversions != '' && inputs.pyversions != 'invalid' ? fromJson(inputs.pyversions) : ['skip'] }}
+        os: ${{ fromJson(inputs.platforms) }}
+        python: ${{ fromJson(inputs.pyversions) }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install rust
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-          source "$HOME/.cargo/env
+          . "$HOME/.cargo/env"
 
       - name: Check version
         run: |

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -20,12 +20,12 @@ on:
         description: Platforms to build for e.g. "['ubuntu-latest','macos-latest','windows-latest']"
         required: false
         type: string
-        default: "['invalid']" #hacky workaround to get things to run
+        default: "invalid" #hacky workaround to get things to run
       pyversions:
         description: Python versions to build for e.g. "['38','39','310','311','312']"
         required: false
         type: string
-        default: "['invalid']" #hacky workaround to get things to run
+        default: "invalid" #hacky workaround to get things to run
       build_args:
         description: Args to pass in to build as `python -m build {build_args}` e.g. '--sdist'
         type: string
@@ -116,13 +116,13 @@ jobs:
 
 
   deploy_wheels:
-    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms != "['invalid']" || inputs.pyversions != "['invalid']" }}
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms != "invalid" || inputs.pyversions != "invalid" }}
     needs: deploy_source
     name: Build wheels and source distribution
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.platforms) }}
-        python: ${{ fromJson(inputs.pyversions) }}
+        os: ${{ inputs.platforms != '' && inputs.platforms != 'invalid' ? fromJson(inputs.platforms) : ['skip'] }}
+        python: ${{ inputs.pyversions != '' && inputs.pyversions != 'invalid' ? fromJson(inputs.pyversions) : ['skip'] }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -33,8 +33,8 @@ jobs:
     name: Build wheels and source distribution
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.platforms) }}
-        python: ${{ fromJson(inputs.python_versions) }}
+        os: ${{ fromJson('[' + inputs.platforms + ']') }}  # Convert comma-separated string into an array
+        python: ${{ fromJson('[' + inputs.python_versions + ']') }}  # Convert comma-separated string into an array
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -16,26 +16,16 @@ on:
         type: string
         required: false
         default: "./"
-      binwheel_platforms:
-        description: For not pure python project, the platforms to build for e.g. "['ubuntu-latest','macos-latest','windows-latest']"
-        required: false
-        type: string
-        default: ''
-      binwheel_pyversions:
-        description: For not pure python project, the Python versions to build for e.g. "['38','39','310','311','312','313']"
-        required: false
-        type: string
-        default: ''
-      purepython_buildargs:
-        description: Args to pass in to build as `python -m build {purepython_buildargs}` e.g. '--sdist'
-          If using binary wheels, set to --sdist to upload just the source distribution.
+      buildargs:
+        description: Args to pass in to build as `python -m build {purepython_buildargs}`
+          e.g. '--sdist' for just source distribution
         type: string
         required: false
         default: ''
 
 
 jobs:
-  deploy_purepython:
+  deploy:
     if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi }}
     runs-on: ubuntu-latest
     defaults:
@@ -114,58 +104,3 @@ jobs:
           # put `local_scheme = "no-local-version"` pyproject.toml's
           # [tools.setuptools_scm]
           twine upload --repository testpypi --verbose dist/*
-
-
-  deploy_binary_wheels:
-    if:  inputs.binwheel_platforms != '' && inputs.binwheel_pyversions != ''
-    needs: deploy_purepython
-    strategy:
-      matrix:
-        platform: ${{ fromJson(inputs.binwheel_platforms) }}
-        python: ${{ fromJson(inputs.binwheel_pyversions) }}
-    runs-on: ${{ matrix.platform }}
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: "0"
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine build cibuildwheel
-
-      - name: Build wheels
-        run: |
-          cibuildwheel --output-dir dist
-        env:
-          CIBW_BUILD: "cp${{ matrix.python }}-*"
-          CIBW_BUILD_VERBOSITY: 1
-
-      - name: Upload to PyPI
-        if: ${{ !inputs.testpypi }}
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          twine check dist/*.whl
-          twine upload dist/*.whl
-
-      - name: Upload to test-PyPI
-        if: ${{ inputs.testpypi }}
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
-        run: |
-          twine check dist/*.whl
-          # HINT: if your upload fails here due to "unsupported local version",
-          # put `local_scheme = "no-local-version"` pyproject.toml's
-          # [tools.setuptools_scm]
-          twine upload --repository testpypi --verbose dist/*.whl

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -109,9 +109,6 @@ jobs:
         env:
           CIBW_BUILD: "cp${{ matrix.python }}-*"
           CIBW_SKIP: "pp*"
-          CIBW_BEFORE_BUILD: |
-            source $HOME/.cargo/env  # Explicitly source Rust environment
-            rustc --version  # Check if rustc is available
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -16,25 +16,26 @@ on:
         type: string
         required: false
         default: "./"
-      platforms:
-        description: Platforms to build for e.g. "['ubuntu-latest','macos-latest','windows-latest']"
+      binwheel_platforms:
+        description: For not pure python project, the platforms to build for e.g. "['ubuntu-latest','macos-latest','windows-latest']"
         required: false
         type: string
         default: ''
-      pyversions:
-        description: Python versions to build for e.g. "['38','39','310','311','312']"
+      binwheel_pyversions:
+        description: For not pure python project, the Python versions to build for e.g. "['38','39','310','311','312','313']"
         required: false
         type: string
         default: ''
-      build_args:
+      purepython_buildargs:
         description: Args to pass in to build as `python -m build {build_args}` e.g. '--sdist'
+          If using binary wheels, set to --sdist to upload just the source distribution.
         type: string
         required: false
         default: ''
 
 
 jobs:
-  deploy_source:
+  deploy_purepython:
     if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi }}
     runs-on: ubuntu-latest
     defaults:
@@ -115,15 +116,14 @@ jobs:
           twine upload --repository testpypi --verbose dist/*
 
 
-  deploy_wheels:
+  deploy_binary_wheels:
     if:  inputs.platforms != '' && inputs.pyversions != ''
-    needs: deploy_source
-    name: Build wheels and source distribution
+    needs: deploy_purepython
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.platforms) }}
+        platform: ${{ fromJson(inputs.platforms) }}
         python: ${{ fromJson(inputs.pyversions) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -155,7 +155,6 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          pip install twine
           twine check dist/*.whl
           twine upload dist/*.whl
 
@@ -165,7 +164,6 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
         run: |
-          pip install twine
           twine check dist/*.whl
           # HINT: if your upload fails here due to "unsupported local version",
           # put `local_scheme = "no-local-version"` pyproject.toml's

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -20,27 +20,17 @@ on:
         description: Platforms to build for.
         required: false
         type: string
-        default: "['ubuntu-latest']"
+        default: "[]"
       pyversions:
         description: Python versions to build for.
         required: false
         type: string
-        default: "['38', '39', '310']"
-      rust: # TODO: use this
-        description: Whether to install rust
-        type: boolean
-        required: false
-        default: false
+        default: "[]"
 
 jobs:
-  deploy:
+  deploy_source:
     if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi }}
-    name: Build wheels and source distribution
-    strategy:
-      matrix:
-        os: ${{ fromJson(inputs.platforms) }}
-        python: ${{ fromJson(inputs.pyversions) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -80,20 +70,71 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine build cibuildwheel
+          pip install setuptools wheel twine build
 
-      # - name: Check version
-      #   run: |
-      #     if [ -f "setup.py" ]; then
-      #       if [ -f "pyproject.toml" ] ; then
-      #         # we need to install eg setuptools_scm to correctly determine version later
-      #         extra_deps=$(python -c 'import tomllib; print(" ".join(f"{e}" for e in tomllib.load(open("pyproject.toml", "rb"))["build-system"]["requires"]))')
-      #         pip install --upgrade $extra_deps
-      #       fi
-      #       version=$(python setup.py --version)
-      #       release=${{ github.ref_name }}
-      #       if [ "${{ inputs.testpypi }}" != "true" ] ; then test "$release" == "$version"; fi
-      #     fi
+      - name: Check version
+        run: |
+          if [ -f "setup.py" ]; then
+            if [ -f "pyproject.toml" ] ; then
+              # we need to install eg setuptools_scm to correctly determine version later
+              extra_deps=$(python -c 'import tomllib; print(" ".join(f"{e}" for e in tomllib.load(open("pyproject.toml", "rb"))["build-system"]["requires"]))')
+              pip install --upgrade $extra_deps
+            fi
+            version=$(python setup.py --version)
+            release=${{ github.ref_name }}
+            if [ "${{ inputs.testpypi }}" != "true" ] ; then test "$release" == "$version"; fi
+          fi
+
+      - name: Build and publish to pypi
+        if: ${{ !inputs.testpypi }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m build --sdist
+          twine check dist/*.tar.gz
+          twine upload dist/*.tar.gz
+
+      - name: Build and publish to testpypi
+        if: ${{ inputs.testpypi }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
+        run: |
+          python -m build --sdist
+          twine check dist/*.tar.gz
+          # HINT: if your upload fails here due to "unsupported local version",
+          # put `local_scheme = "no-local-version"` pyproject.toml's
+          # [tools.setuptools_scm]
+          twine upload --repository testpypi --verbose dist/*.tar.gz
+
+
+  deploy_wheels:
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi }}
+    needs: deploy_source
+    name: Build wheels and source distribution
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.platforms) }}
+        python: ${{ fromJson(inputs.pyversions) }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine build cibuildwheel
 
       - name: Build wheels
         run: |

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -116,7 +116,7 @@ jobs:
 
 
   deploy_wheels:
-    if:  {{ inputs.platforms != '' && inputs.pyversions != '' }}
+    if:  inputs.platforms != '' && inputs.pyversions != ''
     needs: deploy_source
     name: Build wheels and source distribution
     strategy:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -72,6 +72,11 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine build cibuildwheel
+
       - name: Check version
         run: |
           if [ -f "setup.py" ]; then

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -121,8 +121,8 @@ jobs:
     name: Build wheels and source distribution
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.platforms != '' ? inputs.platforms : '["ubuntu-latest"]') }}
-        python: ${{ fromJson(inputs.platforms != '' ? inputs.platforms : '["310"]') }}
+        os: ${{ fromJson(inputs.platforms != '' ? inputs.platforms : '[\"ubuntu-latest\"]') }}
+        python: ${{ fromJson(inputs.pyversions != '' ? inputs.pyversions : '[\"310\"]') }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -82,6 +82,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools wheel twine build cibuildwheel
 
+      - name: Install rust
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+          source "$HOME/.cargo/env
+
       - name: Check version
         run: |
           if [ -f "setup.py" ]; then

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -116,7 +116,7 @@ jobs:
 
 
   deploy_wheels:
-    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms!=\"['invalid']\" || inputs.pyversions!=\"['invalid']\" }}
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms != "['invalid']" || inputs.pyversions != "['invalid']" }}
     needs: deploy_source
     name: Build wheels and source distribution
     strategy:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -120,9 +120,7 @@ jobs:
     needs: deploy_source
     name: Build wheels and source distribution
     strategy:
-      matrix:
-        os: ${{ fromJson(inputs.platforms != '' ? inputs.platforms : '[\"ubuntu-latest\"]') }}
-        python: ${{ fromJson(inputs.pyversions != '' ? inputs.pyversions : '[\"310\"]') }}
+      matrix: ${{ fromJson(format('{{"os": {0}, "python": {1}}}', (inputs.platforms != null && inputs.platforms != '' && inputs.platforms != '[]') && inputs.platforms || '["ubuntu-latest"]', (inputs.pyversions != null && inputs.pyversions != '' && inputs.pyversions != '[]') && inputs.pyversions || '["3.11"]' )) }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -108,7 +108,6 @@ jobs:
           cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: "cp${{ matrix.python }}-*"
-          CIBW_SKIP: "pp*"
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -27,7 +27,7 @@ on:
         type: string
         default: ''
       purepython_buildargs:
-        description: Args to pass in to build as `python -m build {build_args}` e.g. '--sdist'
+        description: Args to pass in to build as `python -m build {purepython_buildargs}` e.g. '--sdist'
           If using binary wheels, set to --sdist to upload just the source distribution.
         type: string
         required: false
@@ -98,7 +98,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python -m build ${{ inputs.build_args }}
+          python -m build ${{ inputs.purepython_buildargs }}
           twine check dist/*
           twine upload dist/*
 
@@ -108,7 +108,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
         run: |
-          python -m build ${{ inputs.build_args }}
+          python -m build ${{ inputs.purepython_buildargs }}
           twine check dist/*
           # HINT: if your upload fails here due to "unsupported local version",
           # put `local_scheme = "no-local-version"` pyproject.toml's
@@ -117,12 +117,12 @@ jobs:
 
 
   deploy_binary_wheels:
-    if:  inputs.platforms != '' && inputs.pyversions != ''
+    if:  inputs.binwheel_platforms != '' && inputs.binwheel_pyversions != ''
     needs: deploy_purepython
     strategy:
       matrix:
-        platform: ${{ fromJson(inputs.platforms) }}
-        python: ${{ fromJson(inputs.pyversions) }}
+        platform: ${{ fromJson(inputs.binwheel_platforms) }}
+        python: ${{ fromJson(inputs.binwheel_pyversions) }}
     runs-on: ${{ matrix.platform }}
     defaults:
       run:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -17,15 +17,21 @@ on:
         required: false
         default: "./"
       platforms:
-        description: Platforms to build for.
+        description: Platforms to build for e.g. "['ubuntu-latest','macos-latest','windows-latest']"
         required: false
         type: string
-        default: "[]"
+        default: ''
       pyversions:
-        description: Python versions to build for.
+        description: Python versions to build for e.g. "['38','39','310','311','312']"
         required: false
         type: string
-        default: "[]"
+        default: ''
+      build_args:
+        description: Args to pass in to build as `python -m build {build_args}` e.g. '--sdist'
+        type: string
+        required: false
+        default: ''
+
 
 jobs:
   deploy_source:
@@ -91,9 +97,9 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python -m build --sdist
-          twine check dist/*.tar.gz
-          twine upload dist/*.tar.gz
+          python -m build ${{ inputs.build_args }}
+          twine check dist/*
+          twine upload dist/*
 
       - name: Build and publish to testpypi
         if: ${{ inputs.testpypi }}
@@ -101,16 +107,16 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
         run: |
-          python -m build --sdist
-          twine check dist/*.tar.gz
+          python -m build ${{ inputs.build_args }}
+          twine check dist/*
           # HINT: if your upload fails here due to "unsupported local version",
           # put `local_scheme = "no-local-version"` pyproject.toml's
           # [tools.setuptools_scm]
-          twine upload --repository testpypi --verbose dist/*.tar.gz
+          twine upload --repository testpypi --verbose dist/*
 
 
   deploy_wheels:
-    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi }}
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi || inputs.platforms!='' || inputs.pyversions!='' }}
     needs: deploy_source
     name: Build wheels and source distribution
     strategy:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -16,11 +16,26 @@ on:
         type: string
         required: false
         default: "./"
+      platforms:
+        description: 'Comma-separated list of platforms to build for (e.g., ubuntu-latest,windows-latest). Default: "ubuntu-latest".'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      python_versions:
+        description: 'Comma-separated list of Python versions to build for (e.g., 3.8, 3.9, 3.10). Default: "3.8, 3.9, 3.10".'
+        required: false
+        type: string
+        default: '3.8, 3.9, 3.10'
 
 jobs:
-  deploy:
+  build:
     if: ${{ github.ref_type == 'tag' || github.event_name == 'release' || inputs.testpypi }}
-    runs-on: ubuntu-latest
+    name: Build wheels and source distribution
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.platforms) }}
+        python: ${{ fromJson(inputs.python_versions) }}
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -28,6 +43,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
+          python-version: ${{ matrix.python }}
 
       - name: Test tag name pattern
         if: ${{ !inputs.testpypi }}
@@ -60,7 +76,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine build
+          pip install setuptools wheel twine build cibuildwheel
 
       - name: Check version
         run: |
@@ -75,23 +91,44 @@ jobs:
             if [ "${{ inputs.testpypi }}" != "true" ] ; then test "$release" == "$version"; fi
           fi
 
-      - name: Build and publish to pypi
+      - name: Build wheels
+        run: |
+          cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp${{ matrix.python }}-*"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: dist
+
+  upload:
+    if: ${{ inputs.upload }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+
+      - name: Upload to PyPI
         if: ${{ !inputs.testpypi }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python -m build
+          pip install twine
           twine check dist/*
           twine upload dist/*
 
-      - name: Build and publish to testpypi
+      - name: Upload to test-PyPI
         if: ${{ inputs.testpypi }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
         run: |
-          python -m build
+          pip install twine
           twine check dist/*
           # HINT: if your upload fails here due to "unsupported local version",
           # put `local_scheme = "no-local-version"` pyproject.toml's


### PR DESCRIPTION
Adds the ability to also build wheels for packages. This is needed e.g. for Rust-Python packages.

This PR:
- maintains the previous functionality by default, but makes it explicit now to only `python -m build --sdist` instead of a generic `python -m build`. The checks on versions etc. are still done here
- adds optional extra task that depends on this first task with the ability to build wheels for config-specified platforms and Python versions

An example successful workflow building wheels for a rust-python package is https://github.com/ecmwf/earthkit-hydro/actions/runs/14662296289/job/41149252856, which is largely driven via the `pyproject.toml`. I have a version on https://github.com/ecmwf/earthkit-hydro/tree/develop that's working