### PR TITLE
fix cd-module repository

### DIFF
--- a/.github/workflows/cd-module.yml
+++ b/.github/workflows/cd-module.yml
@@ -151,5 +151,5 @@ jobs:
           github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
           github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
           troika_user: ${{ secrets.HPC_CI_SSH_USER }}
-          repository: ${{ github.repository }}/${{ github.sha }}
+          repository: ${{ github.repository }}@${{ github.event.pull_request.head.sha || github.sha }}
           build_config: ${{ inputs.config_path }}


### PR DESCRIPTION
parse_package_name method expects input repository name in `owner/name@hash` format