### PR TITLE
PyWrapWheel: update to new wheelmaker version

### DIFF
--- a/.github/workflows/python-wrapper-wheel.yml
+++ b/.github/workflows/python-wrapper-wheel.yml
@@ -23,7 +23,7 @@ jobs:
   linux-wheel:
     name: Build manylinux_2_28
     strategy:
-      fail-fast: false # NOTE primary reason for fail fast is the failure in the clean up step. Once fixed, consider true
+      fail-fast: true # NOTE this is not as good as it looks, because by the time something fails, we may have some wheels published already. Ideally we have one cross-platform pypi push at the end
       matrix:
         # TODO convert this to be matrix-friendly. Note it's a bit tricky since
         # we'd ideally not reexecute the compile step multiple times, but it
@@ -32,7 +32,7 @@ jobs:
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: [self-hosted, Linux, platform-builder-Rocky-8.6]
     container:
-      image: eccr.ecmwf.int/wheelmaker/2_28:latest
+      image: eccr.ecmwf.int/wheelmaker/2_28:multirelease
       options: --user github-actions
       credentials:
         username: ${{ secrets.ECMWF_DOCKER_REGISTRY_USERNAME }}
@@ -40,19 +40,11 @@ jobs:
     steps:
         # NOTE we dont use action checkout because it doesnt cleanup after itself correctly
       - run: git clone --depth=1 --branch="${GITHUB_REF_NAME}" https://github.com/$GITHUB_REPOSITORY /src/proj
-      - run: cd /src/proj && /buildscripts/prepare_deps.sh ./${{ inputs.wheel_directory }}/buildconfig "${{ matrix.python_version }}"
-      - run: cd /src/proj && if [[ -f ./${{ inputs.wheel_directory }}/pre-compile.sh ]] ; then ./${{ inputs.wheel_directory }}/pre-compile.sh ; fi
-      - run: cd /src/proj && /buildscripts/compile.sh ./${{ inputs.wheel_directory }}/buildconfig
-      - run: cd /src/proj && if [[ -f ./${{ inputs.wheel_directory }}/post-compile.sh ]] ; then ./${{ inputs.wheel_directory }}/post-compile.sh ; fi
       - run: |
-          # TODO move this to the dockerfile, but needs to be done per python version
-          # NOTE twine version forced due to metadata issue, cf wheelmaker Dockerfile
-          rm -rf /tmp/buildvenv && uv venv --python python"${{ matrix.python_version }}" /tmp/buildvenv && source /tmp/buildvenv/bin/activate && uv pip install build twine==6.0.1 delocate setuptools requests
+          set -euo pipefail
+          if [ "${{ inputs.use_test_pypi }}" = "true" ] ; then UPLOAD_TO=test ; else UPLOAD_TO=prod ; fi
           cd /src/proj
-          PYTHONPATH=/buildscripts /buildscripts/wheel-linux.sh ./${{ inputs.wheel_directory }}/buildconfig
-          if [[ -f ./${{ inputs.wheel_directory }}/post-build.sh ]] ; then ./${{ inputs.wheel_directory }}/post-build.sh ; fi
-          /buildscripts/test-wheel.sh ./${{ inputs.wheel_directory }}/buildconfig "${{ matrix.python_version }}"
-          TEST_PYPI=${{ inputs.use_test_pypi }} PYTHONPATH=/buildscripts /buildscripts/upload-pypi.sh ./${{ inputs.wheel_directory }}/buildconfig
+          /buildscripts/all.sh "${{ matrix.python_version }}" /venv/ $UPLOAD_TO ${{ inputs.wheel_directory }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD_PROD: ${{ secrets.PYPI_API_TOKEN }}
@@ -66,6 +58,7 @@ jobs:
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: [self-hosted, macOS, "${{ matrix.arch_type }}"]
     steps:
+
       # TODO convert this to be matrix-friendly for python versions. Note it's a bit tricky since
       # we'd ideally not reexecute the compile step multiple times, but it
       # (non-essentially) depends on a matrix-based step
@@ -78,10 +71,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ecmwf/ci-utils
-          ref: develop
+          ref: multirelease
           path: ci-utils
           token: ${{ secrets.GH_REPO_READ_TOKEN }}
       - run: rm -rf proj && git clone --depth=1 --branch="${GITHUB_REF_NAME}" https://github.com/$GITHUB_REPOSITORY proj
+          # TODO simplify this action by calling /buildscripts/all.sh instead of the three next steps
       - run: |
           uv python install python"${{ matrix.python_version }}"
           cd proj && $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/prepare_deps.sh ./${{ inputs.wheel_directory }}/buildconfig "${{ matrix.python_version }}"
@@ -96,9 +90,11 @@ jobs:
           PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/wheel-linux.sh ./${{ inputs.wheel_directory }}/buildconfig "${{ matrix.python_version }}"
           if [[ -f ./${{ inputs.wheel_directory }}/post-build.sh ]] ; then ./${{ inputs.wheel_directory }}/post-build.sh ; fi
           $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/test-wheel.sh ./${{ inputs.wheel_directory }}/buildconfig "${{ matrix.python_version }}"
-          TEST_PYPI=${{ inputs.use_test_pypi }} PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/upload-pypi.sh ./${{ inputs.wheel_directory }}/buildconfig
+          if [ "${{ inputs.use_test_pypi }}" = "true" ] ; then UPLOAD_TO=test ; else UPLOAD_TO=prod ; fi
+          source ./${{ inputs.wheel_directory }}/buildconfig
+          WHEELS=/tmp/$NAME/build/wheel/ # $NAME is from buildconfig
+          PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/upload-pypi.sh $UPLOAD_TO $WHEELS
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
           TWINE_PASSWORD_PROD: ${{ secrets.PYPI_API_TOKEN }}
           TWINE_PASSWORD_TEST: ${{ secrets.PYPI_TEST_API_TOKEN }}


### PR DESCRIPTION
I've done some changes to the wheelmaker docker image, required by the upcoming nightly-develop-build action, but they are not backw compatible -- so I'm adapting here. Once this gets merged, I'll tag the wheelmaker image with `latest` and have another follow-up PR to this reusable action which changes the image tag here back to `latest`

A test of this change can be seen here https://github.com/ecmwf/eckit/actions/runs/14880563882/job/41787484105 -- there were failures, but thats due to network issues. Some actions succeeded and thats it