### PR TITLE
PyWrapWheel: change versioning scheme to maj-latest

### DIFF
--- a/.github/workflows/python-wrapper-wheel.yml
+++ b/.github/workflows/python-wrapper-wheel.yml
@@ -32,7 +32,7 @@ jobs:
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: [self-hosted, Linux, platform-builder-Rocky-8.6]
     container:
-      image: eccr.ecmwf.int/wheelmaker/2_28:multirelease
+      image: eccr.ecmwf.int/wheelmaker/2_28:1.latest
       options: --user github-actions
       credentials:
         username: ${{ secrets.ECMWF_DOCKER_REGISTRY_USERNAME }}
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ecmwf/ci-utils
-          ref: multirelease
+          ref: 1.latest
           path: ci-utils
           token: ${{ secrets.GH_REPO_READ_TOKEN }}
       - run: rm -rf proj && git clone --depth=1 --branch="${GITHUB_REF_NAME}" https://github.com/$GITHUB_REPOSITORY proj


### PR DESCRIPTION
Switching from `latest`-based usage of ci-utils/wheelmaker into `<major>-latest` usage, to facilitate easier breaking changes