### PR TITLE
CI python: Disable Findlibs package

### DIFF
--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -175,6 +175,9 @@ runs:
         echo "pip list:"
         pip list
         cd ${{ steps.inputs.outputs.subdir }}
+        # NOTE we disable findlibs-package as a hotfix because the wheel doesnt come from the
+        # preceeding build (which is the one we want to use for tests here!)
+        export FINDLIBS_DISABLE_PACKAGE=yes
         if [ -n "${{ inputs.test_cmd }}" ]; then
           echo "Running package-supplied test command"
           ${{ inputs.test_cmd }}


### PR DESCRIPTION
CI actions for python packages that depend on a compiled lib tend to fail now, due to the enablement of wheel-based delivery, which however ignores the just-compiled lib. In other words, when we ci-test pyodc, its not using the just-compiled odc, but some older version of it thats on pypi

The proper fix would be about building wheels as well in the ci actions, and using them. But thats more complicated -- so we just globally disable this findlibs part. That leads to the (old) wheel still being installed, but at runtime findlibs would ignore it and pick the just-compiled one.

This has already been done explicitly in the pymultio case -- but it makes more sense to control it globally