### PR TITLE
Add support to publish html to sites

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,83 @@
+# To use this workflow ensure that the calling workflow is run on
+#   pull_request:
+#     types: [opened, synchronize, reopened]
+# If the calling workflow already filters those events the workflow will not work properly.
+name: PR Preview Publish
+
+on:
+  workflow_call:
+    inputs:
+      # Id of the artifact to publish
+      artifact-id:
+        type: string
+        required: true
+      # This is the sites.ecmwf.int space
+      # sites.ecmwf.int/<space>/<name>/<path>/<id>
+      space:
+        type: string
+        required: true
+      # This is the sites.ecmwf.int name
+      # sites.ecmwf.int/<space>/<name>/<path>/<id>
+      name:
+        type: string
+        required: true
+      # This is path under whic to publish the html
+      # Note that below the path another subdirectory will be created with the pattern:
+      # sites.ecmwf.int/<space>/<name>/<path>/<id>
+      path:
+        type: string
+        required: true
+      # This is the final part of the path, e.g. tag/branch name or latest/stable
+      # sites.ecmwf.int/<space>/<name>/<path>/<id>
+      id:
+        type: string
+        required: true
+      # Optional softlink to create, use this to link from latest/stable to concrete
+      # sites.ecmwf.int/<space>/<name>/<path>/<softlink>
+      softlink:
+        type: string
+    secrets:
+      sites-token:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Download artifact containing html to publish
+      - name: Download artifact to publish
+        id: get-artifact
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ inputs.artifact-id }}
+          path: ${{ runner.temp }}/html
+          merge-multiple: true
+
+      # 2. Deploy HTML
+      - name: Publish to ecmwf-sites
+        uses: ecmwf/reuasable-workflows/ecmwf-sites-upload
+        with:
+          token: ${{ secrets.sites-token }}
+          path: ${{ steps.get-artifact.outputs.download-path }}
+          remote_path: ${{ inputs.path }}/${{ inputs.id }}
+          space: ${{ inputs.space }}
+          name: ${{ inputs.name }}
+
+      # 3. Create softlink if desierd
+      - name: Create softlinks
+        if: ${{ inputs.softlink }}
+        run: |
+          curl -X 'PUT' \
+            -H "Authorization: Bearer ${{ secrets.sites-token }}" \
+            -H "Accept: application/json" \
+            https://sites.ecmwf.int/${{ inputs.space }}/${{ inputs.name }}/s/api/v2/symlinks/${{ inputs.path }}/${{ inputs.softlink }}?force=true \
+          -d '{"target": "${{ inputs.path }}/${{ inputs.id }}"}'
+
+      # 4. Update version selector json
+      - name: Update version selectors for tags
+        uses: ecmwf/reusable-workflows/generate-version-selector
+        with:
+          path: ${{ inputs.path }}
+          space: ${{ inputs.space }}
+          name: ${{ inputs.name }}
+          sites-token: ${{ secrets.sites-token }}

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -1,0 +1,78 @@
+# To use this workflow ensure that the calling workflow is run on
+#   pull_request:
+#     types: [opened, synchronize, reopened]
+# If the calling workflow aready filters those events the workflow will not work properly.
+name: PR Preview Publish
+
+on:
+  workflow_call:
+    inputs:
+      # Id of the artifact to publish
+      artifact-id:
+        type: string
+        required: true
+      # This is the sites.ecmwf.int space
+      space:
+        type: string
+        required: true
+      # This is the sites.ecmwf.int name
+      name:
+        type: string
+        required: true
+      # This is path under whic to publish the html
+      # Note that below the path another subdirectory will be created withe pattern PR-<pr-number>
+      # I.e.: sites.ecmwf.int/<space>/<name>/<path>/PR-<PR-number>
+      path:
+        type: string
+        required: true
+      # This tag identifies the preview link in case multiple runs of this workflow add preview links,
+      # e.g., documentation, tests, static-analyzer
+      link-tag:
+        type: string
+        default: PREVIEW-URL
+      link-text:
+        type: string
+        required: true
+    secrets:
+      sites-token:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Download artifact containing HTML to publish if the PR is updated/opened/synced
+      - name: Download artifact to publish
+        if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+        id: get-artifact
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ inputs.artifact-id }}
+          path: ${{ runner.temp }}/html
+          merge-multiple: true
+
+      # 2. Deploy HTML if the PR is updated/opened/synced
+      - name: Publish to ecmwf-sites on pull-request[opened, updated, synchronized]
+        if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+        uses: ecmwf/reusable-workflows/ecmwf-sites-upload
+        with:
+          token: ${{ secrets.sites-token }}
+          path: ${{ steps.get-artifact.outputs.download-path }}
+          remote_path: ${{ inputs.path }}/PR-${{ github.event.number }}
+          space: ${{ inputs.space }}
+          name: ${{ inputs.name }}
+
+      # 3. Update PR description with preview link
+      - name: Update PR body with link
+        if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+        uses: ecmwf/reusable-workflows/update-pr-description
+        with:
+          text: |-
+            ${{ inputs.link-text }}
+            https://sites.ecmwf.int/${{ inputs.space }}/${{ inputs.name }}/${{ inputs.path }}/PR-${{ github.event.number }}
+          marker: ${{ inputs.link-tag }}
+          repo: ${{ github.repository }}
+          pr: ${{ github.event.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/pr-preview-unpublish.yml
+++ b/.github/workflows/pr-preview-unpublish.yml
@@ -1,0 +1,39 @@
+# To use this workflow ensure that the calling workflow is run on
+#   pull_request:
+#     types: [closed]
+# If the calling workflow aready filters those events the workflow will not work properly.
+name: PR Preview Unpublish
+
+on:
+  workflow_call:
+    inputs:
+      # This is the sites.ecmwf.int space
+      space:
+        type: string
+        required: true
+      # This is the sites.ecmwf.int name
+      name:
+        type: string
+        required: true
+      # This is path under whic to publish the html
+      # Note that below the path another subdirectory will be created withe pattern PR-<pr-number>
+      # I.e.: sites.ecmwf.int/<space>/<name>/<path>/PR-<PR-number>
+      path:
+        type: string
+        required: true
+    secrets:
+      sites-token:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete from ecmwf-sites on pull-request[closed]
+        if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+        run: |
+          curl -X DELETE \
+            -H "Authorization: Bearer ${{ secrets.sites-token }}" \
+            -H "Accept: application/json" \
+            https://sites.ecmwf.int/${{ inputs.space }}/${{ inputs.name }}/s/api/v2/files/${{ inputs.path }}/PR-${{ github.event.number }}
+

--- a/ecmwf-sites-upload/action.yml
+++ b/ecmwf-sites-upload/action.yml
@@ -7,6 +7,10 @@ inputs:
   path:
     description: Directory to be uploaded
     required: true
+  remote_path:
+    description: Directory to upload into
+    required: false
+    default: "."
   space:
     description: Name of the site space
     required: true
@@ -24,4 +28,7 @@ runs:
       run: pip install sites-toolkit --upgrade --index-url https://get.ecmwf.int/repository/pypi-all/simple
 
     - shell: bash
-      run: python $GITHUB_ACTION_PATH/upload.py --token=${{ inputs.token }} --path=${{ inputs.path }} --space=${{ inputs.space }} --name=${{ inputs.name }}
+      env:
+        SITES_TOKEN: ${{ inputs.token }}
+      run: |
+        python $GITHUB_ACTION_PATH/upload.py --path=${{ inputs.path }} --remote-path=${{ inputs.remote_path }} --space=${{ inputs.space }} --name=${{ inputs.name }}

--- a/ecmwf-sites-upload/upload.py
+++ b/ecmwf-sites-upload/upload.py
@@ -1,13 +1,14 @@
 import argparse
 import sys
+import os
 
 from sites.sdk import SitesClient
 from sites.sdk.sites import Site, Authenticator
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--token", type=str)
 parser.add_argument("--path", type=str)
+parser.add_argument("--remote-path", type=str, default=".")
 parser.add_argument("--space", type=str)
 parser.add_argument("--name", type=str)
 
@@ -23,14 +24,16 @@ if error:
     sys.exit(1)
 
 # setup authenticated content manager instance
-site_authenticator = Authenticator.from_token(token=args.token)
+site_authenticator = Authenticator.from_token(token=os.environ["SITES_TOKEN"])
 client = SitesClient(authenticator=site_authenticator)
 site = Site.from_space_and_name(space=args.space, name=args.name)
 site_content_manager = client.content(site=site)
 
 # upload all the contents of a directory
 print("Uploading...")
-res = site_content_manager.upload(local_path=args.path, recursive=True)
+res = site_content_manager.upload(
+    local_path=args.path, remote_path=args.remote_path, recursive=True
+)
 print(res)
 if isinstance(res, list) and len(res):
     print(f"Successfully uploaded to sites.ecmwf.int/{args.space}/{args.name}")

--- a/generate-version-selector/action.yaml
+++ b/generate-version-selector/action.yaml
@@ -1,0 +1,25 @@
+name: Generate Version Selector
+description: Generates 'version.json' to be used by sphinx doc. See version_gen.py for more details.
+inputs:
+  path:
+    description: Directory to be scanned
+    required: true
+  space:
+    description: Name of the site space
+    required: true
+  name:
+    description: Name of the site within given space
+    required: true
+  sites-token:
+    description: HTTP access token to write to sites.
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+    - shell: bash
+      env:
+        SITES_TOKEN: ${{ inputs.sites-token }}
+      run: python $GITHUB_ACTION_PATH/version_gen.py --path=${{ inputs.path }} --space=${{ inputs.space }} --name=${{ inputs.name }}

--- a/generate-version-selector/version_gen.py
+++ b/generate-version-selector/version_gen.py
@@ -1,0 +1,101 @@
+#! /usr/bin/env python
+
+import requests
+import json
+import os
+import re
+import argparse
+import sys
+
+
+def parse_cli_args():
+    parser = argparse.ArgumentParser(exit_on_error=False)
+    parser.add_argument("--path", required=True)
+    parser.add_argument("--space", required=True)
+    parser.add_argument("--name", required=True)
+    try:
+        return parser.parse_args()
+    except Exception as e:
+        print(f"::error::Error calling version_gen.py: {e}")
+        sys.exit(1)
+
+
+def main():
+    """
+    This short program will list all directories non- recursively on a path in 
+    sites.ecmwf and generate a 'versions.json' from all paths that match a 
+    version number X.X.X or one of the following names: master, main, develop.
+
+    The resulting versions.json is then uploaded to the same path that has been
+    scanned. This versions.json is supposed to be read by sphinx-version selector
+    to populate the version selection drop-down menu.
+
+    Example:
+    When scanning the below layout with 'documentation' as path a corresponding 
+    version.json will be created
+
+    Layout:
+    my_documentation
+    ├── 1.0.0
+    ├── 1.0.1
+    ├── 1.0.2
+    ├── 1.1.0
+    ├── pull-requests # <= this path will be ignored
+    ├── develop
+    └── main
+
+    version.json:
+    {
+        {"name": "1.0.0", "version": "1.0.0", "url": "sites.ecmwf.int/<space>/<name>/<path>/1.0.0"},
+        {"name": "1.0.1", "version": "1.0.1", "url": "sites.ecmwf.int/<space>/<name>/<path>/1.0.1"},
+        {"name": "1.0.2", "version": "1.0.2", "url": "sites.ecmwf.int/<space>/<name>/<path>/1.0.2"},
+        {"name": "1.1.0", "version": "1.1.0", "url": "sites.ecmwf.int/<space>/<name>/<path>/1.1.0"},
+        {"name": "develop", "version": "develop", "url": "sites.ecmwf.int/<space>/<name>/<path>/develop"},
+        {"name": "master", "version": "master", "url": "sites.ecmwf.int/<space>/<name>/<path>/master"},
+    }
+    """
+    args = parse_cli_args()
+
+    prefix = f"https://sites.ecmwf.int/{args.space}/{args.name}"
+    API_URL = f"{prefix}/s/api/v2/files/{args.path}"
+    headers = {
+        "accept": "*/*",
+        "Authorization": f"Bearer {os.environ['SITES_TOKEN']}",
+    }
+    resp = requests.get(
+        API_URL,
+        headers=headers,
+        timeout=30,
+        params={"list": "true", "limit": "64000", "type": "d"},
+    )
+    if resp.status_code != 200:
+        print(
+            f"::error::Error calling {API_URL} failed with {resp.status_code}: {resp.reason}"
+        )
+        sys.exit(1)
+    data: dict = resp.json()
+
+    regex = re.compile(r"^(?:master|main|develop|latest|stable|\d+\.\d+\.\d+)$")
+    versions = [
+        {
+            "name": x["path"],
+            "version": x["path"],
+            "url": f"{prefix}/{args.path}/{x['path']}",
+        }
+        for x in data["files"]
+        if regex.match(x["path"])
+    ]
+    resp = requests.put(
+        f"{API_URL}/versions.json",
+        files={"file": json.dumps(versions).encode("utf-8")},
+        headers=headers,
+        timeout=30,
+    )
+    if resp.status_code != 200:
+        print(
+            f"::error::Uploading versions.json failed with {resp.status_code}: {resp.reason}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/setup-doxygen/action.yml
+++ b/setup-doxygen/action.yml
@@ -1,0 +1,36 @@
+name: setup-doxygen
+description: Composite action to download, compile and cache doxygen
+inputs:
+  version:
+    description: doxygen version to download
+    default: 1.14.0 
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set Doxygen version
+      run: echo "DOXYGEN_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+      shell: bash
+    - name: Restore cached Doxygen
+      id: doxygen-cache
+      uses: actions/cache@v4
+      with:
+        # Anything you install to this path will be reused on the next run
+        path: ~/.local/doxygen
+        key: doxygen-${{ runner.os }}-${{ env.DOXYGEN_VERSION }}
+    - name: Build Doxygen from source
+      if: steps.doxygen-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        TAG="Release_${DOXYGEN_VERSION//./_}"
+        curl -L -o doxygen.tar.gz "https://github.com/doxygen/doxygen/archive/refs/tags/${TAG}.tar.gz"
+        tar -xf doxygen.tar.gz
+        mkdir -p doxygen-build
+        cd doxygen-${TAG}/
+        mkdir build && cd build
+        cmake -G"Ninja" -DCMAKE_INSTALL_PREFIX="$HOME/.local/doxygen" ..
+        cmake --build . --target install -j32
+    - name: Add Doxygen to PATH
+      run: echo "$HOME/.local/doxygen/bin" >> "$GITHUB_PATH"
+      shell: bash

--- a/update-pr-description/action.yml
+++ b/update-pr-description/action.yml
@@ -1,0 +1,23 @@
+name: Update PR-Description
+description: Updates a PR-Description with a custom payload inside a marker so that the payload can be updated.
+inputs:
+  text:
+    description: text to be added
+    required: true
+  marker:
+    description: unique marker to identify this type of update
+    required: true
+  repo:
+    description: owner/repo 
+    required: true
+  pr:
+    description: PR number
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+    - shell: bash
+      run: python $GITHUB_ACTION_PATH/update-pr-description.py --marker ${{ inputs.marker }} --payload "${{ inputs.text }}" --repo ${{ inputs.repo }} --pr ${{ inputs.pr }}

--- a/update-pr-description/update-pr-description.py
+++ b/update-pr-description/update-pr-description.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+import argparse
+import os
+import re
+import sys
+import textwrap
+from typing import Final
+
+import requests
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+API_ROOT: Final[str] = "https://api.github.com"
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def compile_block_regex(marker: str) -> re.Pattern[str]:
+    """Return a compiled DOTALL regex that captures whatever lies in between
+    the marker lines *including* newlines."""
+    start = f"<!-- {marker}_BEGIN -->"
+    end = f"<!-- {marker}_END -->"
+    return re.compile(
+        rf"{re.escape(start)}(.*?){re.escape(end)}",
+        flags=re.DOTALL,
+    )
+
+
+def get_pr_body(
+    owner: str, repo: str, pr_number: int, session: requests.Session, timeout: int
+) -> str:
+    url = f"{API_ROOT}/repos/{owner}/{repo}/pulls/{pr_number}"
+    response = session.get(url, timeout=timeout)
+    response.raise_for_status()
+    return response.json().get("body") or ""
+
+
+def build_new_body(
+    existing: str, payload: str, marker: str, regex: re.Pattern[str]
+) -> str:
+    start = f"<!-- {marker}_BEGIN -->"
+    end = f"<!-- {marker}_END -->"
+    block = f"{start}\n{payload}\n{end}"
+    if regex.search(existing):
+        return regex.sub(block, existing)
+    sep = "\n\n" if existing.strip() else ""
+    return existing + sep + block
+
+
+def update_pr_body(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    body: str,
+    session: requests.Session,
+    timeout: int,
+) -> None:
+    url = f"{API_ROOT}/repos/{owner}/{repo}/pulls/{pr_number}"
+    response = session.patch(url, json={"body": body}, timeout=timeout)
+    response.raise_for_status()
+
+
+def parse_cli() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Updates PR-Description with a custom payload, e.g. link to doc")
+    parser.add_argument(
+        "--repo", required=True, help="owner/repo, e.g. octocat/Hello-World"
+    )
+    parser.add_argument("--pr", type=int, required=True, help="Pull-request number")
+    parser.add_argument(
+        "--payload", required=True, help="Text/Markdown to hide between markers"
+    )
+    parser.add_argument(
+        "--marker", default="MARKER", help="Opening marker line for the hidden block"
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=15, help="HTTP timeout (seconds)"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_cli()
+    token = os.getenv("GITHUB_TOKEN")
+    if token is None:
+        sys.exit("Error: GITHUB_TOKEN environment variable is not set.")
+
+    owner, repo = args.repo.split("/", maxsplit=1)
+
+    regex = compile_block_regex(args.marker)
+
+    with requests.Session() as session:
+        session.headers.update(
+            {
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        )
+
+        current = get_pr_body(owner, repo, args.pr, session, args.timeout)
+        updated = build_new_body(
+            existing=current,
+            payload=args.payload,
+            marker=args.marker,
+            regex=regex,
+        )
+
+        if updated == current:
+            print("No update: payload already present and identical.")
+            return
+
+        update_pr_body(owner, repo, args.pr, updated, session, args.timeout)
+        print(f"PR #{args.pr} description updated successfully.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a few new reusable workflows:
- Add pr-preview-publish workflow -> Allows publishing a build output to a temporary location -> Updates PR description woth link to output
- Add pr-preview-un-publish workflow -> Removes temporarily published output
- Add doc-publish workflow -> Published a build output to sites -> Optionally allows to create softlinks (e.g. latest/stable) -> Supposed to be used on push to develop/master/main or on tag

Adds a few new composite actions:
- Add new version selector action
- Add build & cache doxygen action
- Add Update PR-desc action

See workflows / actions for more details & documentation.