### PR TITLE
feat: add option to pass env vars to nightly pytest action

### DIFF
--- a/nightly-pytest/action.yml
+++ b/nightly-pytest/action.yml
@@ -30,6 +30,11 @@ inputs:
     required: false
     default: ""
     type: string
+  env-vars:
+    description: "Optional environment variables to set (format: VAR1=value1 VAR2=value2)"
+    required: false
+    default: ""
+    type: string
   manual:
     description: Trigger the action manually and bypass the latest commit check.
     required: false
@@ -79,5 +84,18 @@ runs:
 
     - name: Run integration tests
       if: ${{ env.should_run == 'true' || inputs.manual == 'true' }}
-      run: python -m pytest -v --emoji ${{ inputs.test-directory }} ${{ inputs.pytest-options }}
+      env:
+        INPUT_ENV_VARS: ${{ inputs.env-vars }}
+      run: |
+        # Set environment variables if provided
+        for var_assignment in $INPUT_ENV_VARS; do
+          if [[ "$var_assignment" =~ ^[A-Za-z_][A-Za-z0-9_]*=.*$ ]]; then
+            echo "Setting environment variable: $var_assignment"
+            export "$var_assignment"
+          else
+            echo "Skipping invalid environment variable assignment: $var_assignment"
+          fi
+        done
+
+        python -m pytest -v --emoji ${{ inputs.test-directory }} ${{ inputs.pytest-options }}
       shell: bash


### PR DESCRIPTION
### Description
This adds the option to pass env vars to the nightly pytest action to be set before the pytest command is run. We use this in anemoi to control markers to skip slow running tests etc.

The corresponding PR for a workflow that uses this in anemoi-training is here: https://github.com/ecmwf/anemoi-core/pull/387

And here's a successful run of the action: https://github.com/ecmwf/anemoi-core/actions/runs/15923343211/job/44914932871?pr=387

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 