### PR TITLE
ci-python: Fetch all tags

### DIFF
--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -75,6 +75,8 @@ runs:
         repository: ${{ steps.inputs.outputs.repo }}
         ref: ${{ steps.inputs.outputs.ref }}
         token: ${{ inputs.github_token }}
+        fetch-depth: 0  # pyprojects using setuptools-scm need unshallow fetch to determine version
+        fetch-tags: true
 
     - name: Set env vars from matrix
       if: ${{ inputs.env }}
@@ -159,7 +161,7 @@ runs:
           cd $RUNNER_TEMP/ci-deps/$name/$subdir
           git init
           git remote add origin https://${{ inputs.github_token }}@github.com/$owner/$repo.git
-          git fetch --depth 1 origin $ref
+          git fetch --tags origin $ref
           git checkout FETCH_HEAD
           cd $subdir
           ${{ steps.setup_env.outputs.build_command }}


### PR DESCRIPTION
### Description
In ci-python, the shallow fetching of the package repo and its dependencies causes the Anemois to be installed with an incorrect version. Anemoi uses setuptools-scm to derive the package version from reachable git tags that look like a semver. With a shallow fetch, this fails and it defaults to 0.1

Many anemois set lower bounds on their dependencies. For example, in the downstream-ci of anemoi-a , which is dependent on anemoi-b>0.5 , anemoi-b will initially be installed (from git) with an incorrect version of 0.1. Then when anemoi-a is installed, the dependency of anemoi-b is not satisfied and it will overwrite the previously installed git version with the one from pypi.

The end result is that the final environment does not contain the latest git versions of the dependencies, but the pypi versions. This is solved by fetching all the tags of the dependencies, and to be sure also of the source package (since there may be circular dependencies). 

I tested this and confirmed it solves the issue, and in the Anemois there's very little overhead to fetching the whole repo.

Thanks to @tmi for also spotting this some time ago. 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 