### PR TITLE
Anemoi - Drop Python 3.9 from test matrix

### DIFF
--- a/sync-files/anemoi/all/.github/workflows/python-pull-request.yml
+++ b/sync-files/anemoi/all/.github/workflows/python-pull-request.yml
@@ -19,7 +19,7 @@ jobs:
   checks:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     uses: ecmwf/reusable-workflows/.github/workflows/qa-pytest-pyproject.yml@v2
     with:
       python-version: {% raw %}${{ matrix.python-version }}{% endraw %}


### PR DESCRIPTION
### Description
Anemoi is deprecating Python 3.9 as it's coming to EOL in October.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 