### PR TITLE
Anemoi: Skip pr label workflow on forks

### DIFF
--- a/sync-files/anemoi/all/.github/workflows/pr-label-conventional-commits.yml
+++ b/sync-files/anemoi/all/.github/workflows/pr-label-conventional-commits.yml
@@ -15,7 +15,7 @@ jobs:
   assign-labels:
     runs-on: ubuntu-latest
     name: Assign labels in pull request
-    if: github.event.pull_request.merged == false
+    if: ${{ github.event.pull_request.merged == false && !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/checkout@v3
       - name: Assign labels from Conventional Commits


### PR DESCRIPTION
### Description
This workflow assigns labels to a PR based on semantic commit messages, but it fails on forks because they don't have access to the github token. 

Since the labels are mostly cosmetic, the easy fix is to just skip it for PRs from forks.  

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 