### PR TITLE
add labeler.yml to anemoi repo in sync action

### DIFF
--- a/sync-files/sync.yml
+++ b/sync-files/sync.yml
@@ -195,6 +195,8 @@ group:
       repo_name: anemoi
   - source: sync-files/anemoi/all/.pre-commit-config.yaml
     dest: .pre-commit-config.yaml
+  - source: sync-files/anemoi/all/.github/labeler.yml
+    dest: .github/labeler.yml
   - source: sync-files/general/python/LICENSE
     dest: LICENSE
     template:


### PR DESCRIPTION
### Description

The file-based labeling action currently fails in the anemoi repo because it can't find the file labeler.yml: https://github.com/ecmwf/anemoi/actions/runs/18096779877/job/51489549588?pr=62

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 