### PR TITLE
Upgrade and pin all actions to sha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,17 @@
 version: 2
 updates:
-
   # Maintain dependencies for NPM
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
 
   # Maintain dependencies for GH workflows
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: run build steps
         id: setup

--- a/.github/workflows/cd-module.yml
+++ b/.github/workflows/cd-module.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
 

--- a/.github/workflows/cd-pypi-binwheel.yml
+++ b/.github/workflows/cd-pypi-binwheel.yml
@@ -54,12 +54,12 @@ jobs:
           done
         shell: bash
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
       

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -46,7 +46,7 @@ jobs:
           done
         shell: bash
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
 
@@ -74,7 +74,7 @@ jobs:
           git branch --all --list --format "%(refname:lstrip=3)" --contains "${{ github.ref_name }}" | grep -E "${{ vars.BRANCH_REGEX_FOR_DEPLOYMENT }}"
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check VERSION file content
         shell: python

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -65,13 +65,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ inputs.node_version }}
 
@@ -117,13 +117,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ inputs.node_version }}
 

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -70,13 +70,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python_version }}
 
@@ -174,7 +174,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
@@ -185,7 +185,7 @@ jobs:
       with: ${{ fromJSON(needs.setup.outputs.inputs) }}
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python_version }}
 
@@ -223,13 +223,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
     if: inputs.check_formatting
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ needs.setup.outputs.repository }}
           ref: ${{ needs.setup.outputs.ref }}
@@ -217,7 +217,7 @@ jobs:
     if: inputs.codecov_upload && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || contains(github.event_name, 'pull_request'))
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ needs.setup.outputs.repository }}
           ref: ${{ needs.setup.outputs.ref }}
@@ -262,7 +262,7 @@ jobs:
     runs-on: ${{ matrix.labels }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ needs.setup.outputs.repository }}
           ref: ${{ needs.setup.outputs.ref }}
@@ -270,7 +270,7 @@ jobs:
 
       - name: Restore Dependency Cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         if: inputs.deps_cache_key
         with:
           path: ${{ inputs.deps_cache_path || format('{0}/deps', runner.temp) }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install clang-format
         run: |

--- a/.github/workflows/conda-index-lock.yml
+++ b/.github/workflows/conda-index-lock.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: [self-hosted, platform-builder]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup conda env dir
         shell: bash -el {0}

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -63,7 +63,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
 
@@ -183,7 +183,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.labels }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check version number
         if: ${{ !inputs.skip_checks }}
@@ -248,7 +248,7 @@ jobs:
           github_token: ${{ secrets.github_pat || secrets.GH_REPO_READ_TOKEN || github.token }}
 
       - name: Upload binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ matrix.os }}
           path: ${{ steps.build.outputs.package_path }}

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -46,7 +46,7 @@ jobs:
       # 1. Download artifact containing html to publish
       - name: Download artifact to publish
         id: get-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           artifact-ids: ${{ inputs.artifact-id }}
           path: ${{ runner.temp }}/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
@@ -59,7 +59,7 @@ jobs:
         sudo apt-get -q -y install ${{ inputs.system_dependencies }}
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -77,7 +77,7 @@ jobs:
       release_enabled: ${{ steps.load-config.outputs.release_enabled }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Load and generate matrix
         id: load-config
@@ -103,7 +103,7 @@ jobs:
       matrix: ${{ fromJson(needs.load-config.outputs.build_matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ startsWith(github.ref, 'refs/tags/') && '1' || '50' }}
           fetch-tags: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -254,7 +254,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Prepare release configuration
         id: prepare-config

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Download artifact to publish
         if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
         id: get-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           artifact-ids: ${{ inputs.artifact-id }}
           path: ${{ runner.temp }}/html

--- a/.github/workflows/pr-workflow-check.yml
+++ b/.github/workflows/pr-workflow-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -61,7 +61,7 @@ jobs:
       LOCKED_FLAG: ${{ inputs.locked && '--locked' || '' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Using @master because @stable/@nightly are branch shortcuts that set
       # the default toolchain — redundant when the toolchain input is explicit.
@@ -72,7 +72,7 @@ jobs:
           components: ${{ inputs.run-checks && 'rustfmt, clippy' || '' }}
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Read crate metadata
         id: crate

--- a/.github/workflows/qa-precommit-run.yml
+++ b/.github/workflows/qa-precommit-run.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
     - name: Run pre-commit hooks
-      uses: pre-commit/action@v3.0.1
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       env:
         SKIP: ${{ inputs.skip-hooks }}

--- a/.github/workflows/qa-pytest-pyproject.yml
+++ b/.github/workflows/qa-pytest-pyproject.yml
@@ -57,13 +57,13 @@ jobs:
     name: pytest (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ inputs.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           version: 0.7.19
       - name: Install dependencies
@@ -72,7 +72,7 @@ jobs:
         run: |
           uv pip install .[${{ inputs.optional-dependencies }}] pytest pytest-md pytest-emoji
       - name: Run pytest
-        uses: pavelzw/pytest-action@v2
+        uses: pavelzw/pytest-action@510c5e90c360a185039bea56ce8b3e7e51a16507 # v2.2.0
         with:
           verbose: true
           emoji: ${{ inputs.emoji }}

--- a/.github/workflows/sync-files-to-repos.yml
+++ b/.github/workflows/sync-files-to-repos.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Repo File Sync Action
-        uses: BetaHuhn/repo-file-sync-action@v1
+        uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619 # v1.21.1
         with:
           GH_PAT: ${{ secrets.REPO_SYNC_ACTION_PAT }}
           GIT_EMAIL: "150700357+DeployDuck@users.noreply.github.com"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ inputs.node_version }}
 

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+
+ignore_actions:
+  - name: ^ecmwf/.*
+    ref: .*

--- a/README.md
+++ b/README.md
@@ -646,6 +646,26 @@ npm install
 npm run lint
 ```
 
+## Action Pinning
+
+This repository uses [pinact] to pin GitHub Actions and reusable workflows to their commit SHA for security. Actions from the `ecmwf` organisation and files under `sync-files/` are excluded from pinning.
+
+### Running pinact
+
+To pin actions in workflow files and documentation:
+
+```
+pinact run
+```
+
+To update pinned actions to their latest versions (skipping versions released less than 7 days ago):
+
+```
+pinact run -u --min-age 7
+```
+
+For installation instructions, see the [pinact documentation][pinact-install].
+
 ## Licence
 
 This software is licensed under the terms of the Apache License Version 2.0 which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -655,5 +675,7 @@ In applying this licence, ECMWF does not waive the privileges and immunities gra
 [reusable GitHub workflows]: https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
 [Samples]: https://github.com/ecmwf/reusable-workflows/tree/develop/samples
 [codecov service]: https://codecov.io
+[pinact]: https://github.com/suzuki-shunsuke/pinact
+[pinact-install]: https://github.com/suzuki-shunsuke/pinact/blob/main/INSTALL.md
 [inputs for the build-package]: https://github.com/ecmwf/build-package#inputs
 [inputs for the sync-repository]: https://github.com/ecmwf/sync-repository#inputs

--- a/build-package-with-config/action.yml
+++ b/build-package-with-config/action.yml
@@ -58,7 +58,7 @@ runs:
             print("ref", ref, sep="=", file=f)
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ steps.inputs.outputs.repo }}
         ref: ${{ steps.inputs.outputs.ref }}
@@ -146,7 +146,7 @@ runs:
 
     - name: Codecov Upload
       if: ${{ inputs.codecov_upload == 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || contains(github.event_name, 'pull_request')) && steps.build.outputs.coverage_file }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
         files: ${{ steps.build.outputs.coverage_file }}
         token: ${{ inputs.codecov_token }}

--- a/cd-actions/conda/action.yml
+++ b/cd-actions/conda/action.yml
@@ -138,7 +138,7 @@ runs:
         fi
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ github.run_id }}-${{ inputs.name }}
         path: ${{ steps.config.outputs.artifact_pattern }}

--- a/cd-actions/confluence-upload/action.yml
+++ b/cd-actions/confluence-upload/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       with:
         python-version: '3.13'
 

--- a/cd-actions/python-pypi/action.yml
+++ b/cd-actions/python-pypi/action.yml
@@ -76,7 +76,7 @@ runs:
         uv publish --publish-url https://test.pypi.org/legacy/
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ github.run_id }}-${{ inputs.name }}
         path: ${{ inputs.working_directory }}/dist/*.whl

--- a/cd-actions/release/action.yml
+++ b/cd-actions/release/action.yml
@@ -50,7 +50,7 @@ runs:
         print(f"Make latest: {make_latest}")
         
     - name: Download all artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: ${{ github.run_id }}-*
         merge-multiple: true
@@ -92,7 +92,7 @@ runs:
 
     - name: Create GitHub release with artifacts
       if: ${{ steps.files.outputs.has_files == 'true' }}
-      uses: softprops/action-gh-release@aec2ec56f94eb8180ceec724245f64ef008b89f5 # v2.4.0
+      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
       with:
         tag_name: ${{ inputs.ref_name }}
         name: ${{ steps.config.outputs.release_name }}

--- a/cd-actions/system-package/action.yml
+++ b/cd-actions/system-package/action.yml
@@ -466,7 +466,7 @@ runs:
         echo "Package installation test passed"
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ github.run_id }}-${{ inputs.name }}
         path: ${{ steps.build.outputs.package_path }}

--- a/cd-actions/tarball/action.yml
+++ b/cd-actions/tarball/action.yml
@@ -140,7 +140,7 @@ runs:
         echo "safe_ref_name=${ref_name//\//-}" >> $GITHUB_OUTPUT
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ github.run_id }}-${{ inputs.name }}-${{ steps.sanitize.outputs.safe_ref_name }}
         path: ${{ steps.find-tarball.outputs.tarball_path }}

--- a/check-upstream-conclusion/action.yml
+++ b/check-upstream-conclusion/action.yml
@@ -16,8 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    # v7 uses Node20, which cannot run out of the box on CentOS7
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         github-token: ${{ inputs.token }}
         script: |
@@ -49,9 +48,9 @@ runs:
           for (const dep of deps){
             for (const job of jobs){
               if (
-                job.name.toLowerCase().includes(`/ ${dep} (`) && 
-                job.name.toLowerCase().includes(platformName) && 
-                job.status == "completed" && 
+                job.name.toLowerCase().includes(`/ ${dep} (`) &&
+                job.name.toLowerCase().includes(platformName) &&
+                job.status == "completed" &&
                 job.conclusion == "failure"
               ){
                 core.setFailed(`==> Build of upstream package ${dep} failed on platform ${platformName}, exiting.`);

--- a/ci-hpc/action.yml
+++ b/ci-hpc/action.yml
@@ -105,7 +105,7 @@ runs:
             print("py_deps", py_deps, sep="=", file=f)
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ steps.inputs.outputs.repo }}
         ref: ${{ steps.inputs.outputs.ref }}

--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Checkout repository
       if: ${{ inputs.checkout == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ steps.inputs.outputs.repo }}
         ref: ${{ steps.inputs.outputs.ref }}
@@ -224,13 +224,13 @@ runs:
 
     - name: Upload Extra Artifact
       if: ${{ always() && inputs.upload_extra_artifact != 'none' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ inputs.upload_extra_artifact }}-${{ matrix.os }}-${{ matrix.compiler }}-${{ github.run_id }}-${{ github.run_attempt }}
         path: ${{ inputs.upload_extra_artifact }}/
 
     - name: Codecov Upload
       if: ${{ inputs.codecov_upload == 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || contains(github.event_name, 'pull_request')) }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
         token: ${{ inputs.codecov_token }}

--- a/ecmwf-sites-upload/action.yml
+++ b/ecmwf-sites-upload/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
 

--- a/generate-version-selector/action.yaml
+++ b/generate-version-selector/action.yaml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.13'
     - shell: bash

--- a/nightly-pytest/action.yml
+++ b/nightly-pytest/action.yml
@@ -39,7 +39,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -64,7 +64,7 @@ runs:
 
     - name: Set up Python
       if: ${{ env.should_run == 'true' || inputs.manual == 'true' }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'

--- a/setup-doxygen/action.yml
+++ b/setup-doxygen/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
     - name: Restore cached Doxygen
       id: doxygen-cache
-      uses: actions/cache@v4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         # Anything you install to this path will be reused on the next run
         path: ~/.local/doxygen

--- a/update-pr-description/action.yml
+++ b/update-pr-description/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.13'
     - shell: bash


### PR DESCRIPTION
### Description

This PR updates all 3rd party GitHub actions and pins them to a sha

Some of the updates might bring breaking changes to the repo, needs to be tested


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 