### PR TITLE
Import sys module in cd-docs.yml

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -19,6 +19,7 @@ jobs:
           import json
           import os
           import subprocess
+          import sys
           import yaml
 
           config_path = "${{ inputs.config }}"


### PR DESCRIPTION
Needed for the `sys.exit()` call.