### PR TITLE
Remove mambabuild and use libmamba resolver instead

### DIFF
--- a/.github/workflows/conda-index-lock.yml
+++ b/.github/workflows/conda-index-lock.yml
@@ -115,7 +115,7 @@ jobs:
           EOF
 
           echo "Downloaded packages:"
-          find ./packages -name "*.tar.bz2" | sort
+          find ./packages -type f \( -name "*.tar.bz2" -o -name "*.conda" \) | sort
 
       - name: Rebuild conda index
         shell: bash -el {0}

--- a/cd-actions/conda/action.yml
+++ b/cd-actions/conda/action.yml
@@ -188,8 +188,11 @@ runs:
             echo "Testing installation of: $package_name"
 
             # Extract package name and version
-            pkg_base=$(echo "$package_name" | sed -E 's/-[0-9]+(\.[0-9]+)*-.*//')
-            pkg_version=$(echo "$package_name" | sed -E 's/^[^-]+-([0-9]+(\.[0-9]+)*).*/\1/')
+            pkg_stem="${package_name%.conda}"
+            pkg_stem="${pkg_stem%.tar.bz2}"
+            pkg_no_build="${pkg_stem%-*}"
+            pkg_base="${pkg_no_build%-*}"
+            pkg_version="${pkg_no_build##*-}"
 
             echo "Package: $pkg_base"
             echo "Version: $pkg_version"

--- a/cd-actions/conda/action.yml
+++ b/cd-actions/conda/action.yml
@@ -38,7 +38,7 @@ inputs:
     required: false
     default: 'conda-forge'
   conda_build_args:
-    description: 'Additional arguments for conda mambabuild command as line-separated values'
+    description: 'Additional arguments for conda build command as line-separated values'
     required: false
     default: '--no-anaconda-upload'
 
@@ -90,7 +90,7 @@ runs:
       run: |
         eval "$(conda shell.bash hook)"
         conda activate "$BUILD_ENV"
-        mamba install -y conda conda-build boa conda-verify conda-index
+        mamba install -y conda conda-build conda-verify conda-index
         mamba info
         mamba list
         
@@ -114,7 +114,8 @@ runs:
 
         mkdir -p "$output_folder"
 
-        conda mambabuild "$meta_dir" -c $nexus_url $channels --output-folder "$output_folder" --no-anaconda-upload $build_args
+        export CONDA_SOLVER=libmamba
+        "$CONDA_PREFIX/bin/conda" build "$meta_dir" -c $nexus_url $channels --output-folder "$output_folder" --no-anaconda-upload $build_args
         
     - name: List built packages
       shell: bash -el {0}

--- a/cd-actions/conda/action.yml
+++ b/cd-actions/conda/action.yml
@@ -122,7 +122,7 @@ runs:
       run: |
         output_folder="${{ steps.config.outputs.output_folder }}"
         echo "Built packages:"
-        find "$output_folder" -name "*.tar.bz2" -o -name "*.tar.bz2" | sort
+        find "$output_folder" \( -name "*.tar.bz2" -o -name "*.conda" \) -type f | sort
         
     - name: Verify artifacts
       shell: bash -el {0}
@@ -131,7 +131,7 @@ runs:
         echo "Checking for conda packages in: $output_folder"
 
         # Check if conda packages exist in output folder
-        if ! find "$output_folder" -name "*.tar.bz2" -type f | head -1 | grep -q .; then
+        if ! find "$output_folder" -type f \( -name "*.tar.bz2" -o -name "*.conda" \) | head -1 | grep -q .; then
             echo "No conda packages found in: $output_folder"
             echo "Available files:"
             find "$output_folder" -type f | head -20
@@ -180,7 +180,7 @@ runs:
         echo "Testing package installation from Nexus..."
 
         # Get package name and version from built packages
-        packages=$(find "$output_folder" -name "*.tar.bz2" -type f)
+        packages=$(find "$output_folder" -type f \( -name "*.tar.bz2" -o -name "*.conda" \))
 
         for package in $packages; do
             package_name=$(basename "$package")

--- a/cd-actions/conda/scripts/parse_config.py
+++ b/cd-actions/conda/scripts/parse_config.py
@@ -36,13 +36,16 @@ def main():
 
     meta_file = f"{conda_dir}/meta.yaml"
     output_folder = f"{conda_dir}/build"
-    artifact_pattern = f"{output_folder}/**/*.tar.bz2"
+    artifact_patterns = [f"{output_folder}/**/*.tar.bz2", f"{output_folder}/**/*.conda"]
+    artifact_pattern = "\n".join(artifact_patterns)
 
     with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
         f.write(f"meta_file={meta_file}\n")
         f.write(f"channels={channels}\n")
         f.write(f"output_folder={output_folder}\n")
-        f.write(f"artifact_pattern={artifact_pattern}\n")
+        f.write("artifact_pattern<<ARTIFACT_PATTERN_EOF\n")
+        f.write(f"{artifact_pattern}\n")
+        f.write("ARTIFACT_PATTERN_EOF\n")
         f.write(f"conda_build_args={conda_build_args}\n")
         f.write(f"nexus_url={nexus_url}\n")
         f.write(f"nexus_token={nexus_token}\n")


### PR DESCRIPTION
### Description

Removes deprecated boa installation and uses `conda build` with `libmamba` resolver as a replacement

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
