### PR TITLE
Add umask handling for git credentials setup when using ecbundle

### DIFF
--- a/cd-actions/hpc/templates/ecbundle.jinja
+++ b/cd-actions/hpc/templates/ecbundle.jinja
@@ -26,11 +26,13 @@ export PATH="{{ ci_options.workdir }}/ecbundle/bin:$PATH"
 {# Configure git credentials for private repos #}
 {{ start_group("Configure git credentials") }}
 git config --global credential.helper store
+old_umask=$(umask) # backup previous umask
 umask 077
 cat > ~/.git-credentials << 'CREDS'
 https://{{ github.user }}:{{ github.token }}@github.com
 https://{{ github.user }}:{{ github.token }}@git.ecmwf.int
 CREDS
+umask "$old_umask" # restore previous umask
 {{ end_group() }}
 
 {# ecbundle-create: Clone all projects from bundle.yml #}


### PR DESCRIPTION
Backup and restore the previous umask when configuring git credentials.

### Description
This is so that an hpc installation uses the normal umask rather than the one used when setting temporary GitHub credentials.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
