### PR TITLE
Do not clean before installation by default

### DIFF
--- a/.github/workflows/cd-hpc.yml
+++ b/.github/workflows/cd-hpc.yml
@@ -89,7 +89,7 @@ on:
         type: string
         default: ''
       clean_before_install:
-        description: 'Remove existing install directory before install'
+        description: 'Remove existing install directory before install. Dry-run installs into $SCRATCH are always cleaned automatically.'
         required: false
         type: string
         default: 'false'

--- a/cd-actions/hpc/templates/cmake.jinja
+++ b/cd-actions/hpc/templates/cmake.jinja
@@ -42,6 +42,10 @@ else
     {{ load_modules(generic_modules, package.modules) }}
     {{ set_env(env) }}
 
+    {% if package.type == "main" and ci_options.ecbundle %}
+    {{ clean_install_dir(package) }}
+    {% endif %}
+
     {{ start_group( "Building " + package.name) }}
     {% if package.name == "ecbuild" %}
     {{ cd_pkg_subdir(package) }}
@@ -68,7 +72,7 @@ else
     {% endif %}
     {{ end_group() }}
 
-    {% if package.type == "main" %}
+    {% if package.type == "main" and not ci_options.ecbundle %}
     {{ clean_install_dir(package) }}
     {% endif %}
 

--- a/cd-actions/hpc/templates/environment.jinja
+++ b/cd-actions/hpc/templates/environment.jinja
@@ -63,29 +63,58 @@ echo "Repository: {{ ci_options.main_package_name }}"
 {# === Clean Install Directory === #}
 {% macro clean_install_dir(package) -%}
 {% set is_main = package.type in ["main", "main-python", "ecbundle"] %}
+{% set auto_dry_run_clean = ci_options.dry_run and ci_options.dry_run_install %}
 {% if is_main and ci_options.skip_install %}
-{% elif ci_options.clean_before_install %}
+{% elif ci_options.clean_before_install or auto_dry_run_clean %}
 {{ start_group("Cleaning before install: " + package.name) }}
 if cd {{ package.prefix }} 2>/dev/null; then
   # Resolve symlinks and '..' then validate the path is safe to clean.
-  # Allowed: /usr/local/apps/<app>/<version-or-deeper>, or any path under $TMPDIR / $SCRATCH.
-  CLEAN_PATH="$(realpath "{{ package.prefix }}")"
+  if ! CLEAN_PATH="$(realpath -e "{{ package.prefix }}")"; then
+      echo "SAFETY ERROR: Refusing to clean {{ package.prefix }} - could not resolve target path"
+      exit 1
+  fi
+{% if ci_options.clean_before_install %}
+  TMPDIR_PATH=""
+  if [[ -n "${TMPDIR:-}" ]] && ! TMPDIR_PATH="$(realpath -e "$TMPDIR")"; then
+      echo "SAFETY ERROR: Refusing to clean $CLEAN_PATH - could not resolve \$TMPDIR"
+      exit 1
+  fi
+  SCRATCH_PATH=""
+  if [[ -n "${SCRATCH:-}" ]] && ! SCRATCH_PATH="$(realpath -e "$SCRATCH")"; then
+      echo "SAFETY ERROR: Refusing to clean $CLEAN_PATH - could not resolve \$SCRATCH"
+      exit 1
+  fi
   if [[ "$CLEAN_PATH" == /usr/local/apps/* ]]; then
       if [[ ! "$CLEAN_PATH" =~ ^/usr/local/apps/[^/]+/.+ ]]; then
           echo "SAFETY ERROR: Refusing to clean $CLEAN_PATH - path must be at least /usr/local/apps/<app>/<version>"
           exit 1
       fi
-  elif [[ -n "${TMPDIR:-}" && "$CLEAN_PATH" == "${TMPDIR}"/* ]]; then
+  elif [[ -n "$TMPDIR_PATH" && "$CLEAN_PATH" == "$TMPDIR_PATH"/* ]]; then
     :
-  elif [[ -n "${SCRATCH:-}" && "$CLEAN_PATH" == "${SCRATCH}"/* ]]; then
+  elif [[ -n "$SCRATCH_PATH" && "$CLEAN_PATH" == "$SCRATCH_PATH"/* ]]; then
     :
   else
       echo "SAFETY ERROR: Refusing to clean $CLEAN_PATH - not under /usr/local/apps/<app>/<version>, \$TMPDIR, or \$SCRATCH"
       exit 1
   fi
+{% else %}
+  # Automatic dry-run cleaning: only ever permitted under $SCRATCH.
+  if [[ -z "${SCRATCH:-}" ]]; then
+      echo "SAFETY ERROR: Refusing automatic dry-run clean of $CLEAN_PATH - \$SCRATCH is not set. Set clean_before_install: true to clean other locations."
+      exit 1
+  fi
+  if ! SCRATCH_PATH="$(realpath -e "$SCRATCH")"; then
+      echo "SAFETY ERROR: Refusing automatic dry-run clean of $CLEAN_PATH - could not resolve \$SCRATCH"
+      exit 1
+  fi
+  if [[ "$CLEAN_PATH" != "$SCRATCH_PATH"/* ]]; then
+      echo "SAFETY ERROR: Refusing automatic dry-run clean of $CLEAN_PATH - not under \$SCRATCH. Set clean_before_install: true to clean other locations."
+      exit 1
+  fi
+{% endif %}
   echo "Removing the previous install: {{ package.prefix }}"
   find . -type f -or -type d -exec chmod u+w {} \;
-  rm -rfv ./*
+  find . -mindepth 1 -maxdepth 1 -exec rm -rfv -- {} +
   cd -
 else
   echo "Nothing to clean up."

--- a/cd-actions/hpc/templates/environment.jinja
+++ b/cd-actions/hpc/templates/environment.jinja
@@ -75,14 +75,12 @@ if cd {{ package.prefix }} 2>/dev/null; then
   fi
 {% if ci_options.clean_before_install %}
   TMPDIR_PATH=""
-  if [[ -n "${TMPDIR:-}" ]] && ! TMPDIR_PATH="$(realpath -e "$TMPDIR")"; then
-      echo "SAFETY ERROR: Refusing to clean $CLEAN_PATH - could not resolve \$TMPDIR"
-      exit 1
+  if [[ -n "${TMPDIR:-}" ]]; then
+      TMPDIR_PATH="$(realpath -e "$TMPDIR" 2>/dev/null)" || TMPDIR_PATH=""
   fi
   SCRATCH_PATH=""
-  if [[ -n "${SCRATCH:-}" ]] && ! SCRATCH_PATH="$(realpath -e "$SCRATCH")"; then
-      echo "SAFETY ERROR: Refusing to clean $CLEAN_PATH - could not resolve \$SCRATCH"
-      exit 1
+  if [[ -n "${SCRATCH:-}" ]]; then
+      SCRATCH_PATH="$(realpath -e "$SCRATCH" 2>/dev/null)" || SCRATCH_PATH=""
   fi
   if [[ "$CLEAN_PATH" == /usr/local/apps/* ]]; then
       if [[ ! "$CLEAN_PATH" =~ ^/usr/local/apps/[^/]+/.+ ]]; then

--- a/cd-actions/tests/requirements.txt
+++ b/cd-actions/tests/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml
 pytest
+jinja2

--- a/cd-actions/tests/test_hpc_cleanup.py
+++ b/cd-actions/tests/test_hpc_cleanup.py
@@ -1,0 +1,215 @@
+"""Render-and-execute tests for the HPC install cleanup macro."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+
+TEMPLATE_DIR = Path(__file__).parent.parent / "hpc" / "templates"
+JINJA_ENV = Environment(
+    loader=FileSystemLoader(TEMPLATE_DIR),
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+JINJA_ENV.filters["strip_d_prefix"] = (
+    lambda value: value[2:] if value.startswith("-D") else value
+)
+CLEAN_TEMPLATE = JINJA_ENV.from_string(
+    "{% from 'environment.jinja' import clean_install_dir with context %}"
+    "{{ clean_install_dir(package) }}"
+)
+CMAKE_TEMPLATE = JINJA_ENV.from_string(
+    "{% from 'cmake.jinja' import cmake_package with context %}"
+    "{{ cmake_package(package) }}"
+)
+
+
+def _render_cleanup(prefix: Path, *, explicit: bool = False) -> str:
+    return CLEAN_TEMPLATE.render(
+        package={"name": "test-package", "prefix": str(prefix), "type": "main"},
+        ci_options={
+            "clean_before_install": explicit,
+            "dry_run": True,
+            "dry_run_install": True,
+            "skip_install": False,
+        },
+    )
+
+
+def _run_cleanup(
+    prefix: Path,
+    *,
+    scratch: Path | str | None = None,
+    tmpdir: Path | str | None = None,
+    explicit: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("SCRATCH", None)
+    env.pop("TMPDIR", None)
+    if scratch is not None:
+        env["SCRATCH"] = str(scratch)
+    if tmpdir is not None:
+        env["TMPDIR"] = str(tmpdir)
+
+    return subprocess.run(
+        ["bash", "-e", "-o", "pipefail"],
+        input=_render_cleanup(prefix, explicit=explicit),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def _render_cmake_package(*, ecbundle: bool) -> str:
+    return CMAKE_TEMPLATE.render(
+        package={
+            "name": "test-package",
+            "owner": "test-owner",
+            "repo": "test-package",
+            "ref": "main",
+            "type": "main",
+            "prefix": "${SCRATCH}/dry-run-install/test-package/main",
+            "cmake_options": [],
+            "ctest_options": [],
+            "modules": [],
+            "cache_key": "unused",
+            "subdir": "",
+            "install_command": "",
+        },
+        ci_options={
+            "workdir": "${TMPDIR}",
+            "force_build": False,
+            "hpc_config": {"enable_cache": False},
+            "ecbundle": ecbundle,
+            "cpus_per_task": 4,
+            "skip_install": False,
+            "self_test": False,
+            "clean_before_install": False,
+            "dry_run": True,
+            "dry_run_install": True,
+        },
+        github={"user": "test-user", "token": "test-token"},
+        generic_modules=[],
+        env=[],
+    )
+
+
+def _populate_install(prefix: Path) -> None:
+    prefix.mkdir(parents=True)
+    (prefix / "regular-file").write_text("regular\n")
+    (prefix / ".hidden-file").write_text("hidden\n")
+    hidden_dir = prefix / ".hidden-directory"
+    hidden_dir.mkdir()
+    (hidden_dir / "nested-file").write_text("nested\n")
+
+
+def test_automatic_cleanup_canonicalizes_symlinked_scratch(tmp_path):
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    scratch_link = tmp_path / "scratch-link"
+    scratch_link.symlink_to(scratch, target_is_directory=True)
+    prefix = scratch_link / "install"
+    _populate_install(prefix)
+
+    result = _run_cleanup(prefix, scratch=scratch_link)
+
+    assert result.returncode == 0, result.stderr
+    assert prefix.is_dir()
+    assert list(prefix.iterdir()) == []
+
+
+def test_automatic_cleanup_canonicalizes_dot_dot_in_scratch(tmp_path):
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    prefix = scratch / "install"
+    _populate_install(prefix)
+    (tmp_path / "unused").mkdir()
+    noncanonical_scratch = tmp_path / "unused" / ".." / "scratch"
+
+    result = _run_cleanup(prefix, scratch=noncanonical_scratch)
+
+    assert result.returncode == 0, result.stderr
+    assert prefix.is_dir()
+    assert list(prefix.iterdir()) == []
+
+
+def test_automatic_cleanup_rejects_target_outside_scratch(tmp_path):
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    prefix = tmp_path / "outside" / "install"
+    _populate_install(prefix)
+
+    result = _run_cleanup(prefix, scratch=scratch)
+
+    assert result.returncode != 0
+    assert "not under $SCRATCH" in result.stdout
+    assert (prefix / "regular-file").is_file()
+    assert (prefix / ".hidden-file").is_file()
+    assert (prefix / ".hidden-directory").is_dir()
+
+
+def test_automatic_cleanup_rejects_scratch_root_itself(tmp_path):
+    scratch = tmp_path / "scratch"
+    _populate_install(scratch)
+
+    result = _run_cleanup(scratch, scratch=scratch)
+
+    assert result.returncode != 0
+    assert "not under $SCRATCH" in result.stdout
+    assert (scratch / "regular-file").is_file()
+
+
+@pytest.mark.parametrize("root_variable", ["TMPDIR", "SCRATCH"])
+def test_explicit_cleanup_canonicalizes_environment_roots(tmp_path, root_variable):
+    root = tmp_path / root_variable.lower()
+    root.mkdir()
+    root_link = tmp_path / f"{root_variable.lower()}-link"
+    root_link.symlink_to(root, target_is_directory=True)
+    prefix = root_link / "install"
+    _populate_install(prefix)
+    kwargs = {root_variable.lower(): root_link}
+
+    result = _run_cleanup(prefix, explicit=True, **kwargs)
+
+    assert result.returncode == 0, result.stderr
+    assert prefix.is_dir()
+    assert list(prefix.iterdir()) == []
+
+
+def test_cleanup_rejects_unresolvable_required_root(tmp_path):
+    prefix = tmp_path / "install"
+    _populate_install(prefix)
+    missing_scratch = tmp_path / "missing-scratch"
+
+    result = _run_cleanup(prefix, scratch=missing_scratch)
+
+    assert result.returncode != 0
+    assert "could not resolve $SCRATCH" in result.stdout
+    assert (prefix / "regular-file").is_file()
+
+
+def test_legacy_ecbundle_cleanup_precedes_combined_build_and_install():
+    rendered = _render_cmake_package(ecbundle=True)
+
+    cleanup = rendered.index("Cleaning before install: test-package")
+    build_and_install = rendered.index("ecbundle build --install")
+
+    assert cleanup < build_and_install
+    assert rendered.count("Cleaning before install: test-package") == 1
+
+
+def test_standard_cmake_cleanup_remains_between_build_and_install():
+    rendered = _render_cmake_package(ecbundle=False)
+
+    build = rendered.index("time cmake --build .")
+    cleanup = rendered.index("Cleaning before install: test-package")
+    install = rendered.index("time cmake --install .")
+
+    assert build < cleanup < install
+    assert rendered.count("Cleaning before install: test-package") == 1

--- a/cd-actions/tests/test_hpc_cleanup.py
+++ b/cd-actions/tests/test_hpc_cleanup.py
@@ -182,6 +182,47 @@ def test_explicit_cleanup_canonicalizes_environment_roots(tmp_path, root_variabl
     assert list(prefix.iterdir()) == []
 
 
+@pytest.mark.parametrize(
+    ("available_root", "unresolvable_root"),
+    [("tmpdir", "scratch"), ("scratch", "tmpdir")],
+)
+def test_explicit_cleanup_ignores_unresolvable_optional_root(
+    tmp_path, available_root, unresolvable_root
+):
+    root = tmp_path / available_root
+    root.mkdir()
+    prefix = root / "install"
+    _populate_install(prefix)
+    kwargs = {
+        available_root: root,
+        unresolvable_root: tmp_path / f"missing-{unresolvable_root}",
+    }
+
+    result = _run_cleanup(prefix, explicit=True, **kwargs)
+
+    assert result.returncode == 0, result.stderr
+    assert prefix.is_dir()
+    assert list(prefix.iterdir()) == []
+
+
+def test_explicit_cleanup_rejects_target_outside_available_roots(tmp_path):
+    prefix = tmp_path / "outside" / "install"
+    _populate_install(prefix)
+
+    result = _run_cleanup(
+        prefix,
+        explicit=True,
+        tmpdir=tmp_path / "missing-tmpdir",
+        scratch=tmp_path / "missing-scratch",
+    )
+
+    assert result.returncode != 0
+    assert "not under /usr/local/apps" in result.stdout
+    assert (prefix / "regular-file").is_file()
+    assert (prefix / ".hidden-file").is_file()
+    assert (prefix / ".hidden-directory").is_dir()
+
+
 def test_cleanup_rejects_unresolvable_required_root(tmp_path):
     prefix = tmp_path / "install"
     _populate_install(prefix)


### PR DESCRIPTION
### Description

This PR swaps the default value for pre-installation cleanup making in opt-in while keeping the cleanup for dry runs with installs in scratch dir

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
