### PR TITLE
Install cffi from source

### DIFF
--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -111,7 +111,11 @@ runs:
           build_command="uv build --sdist --no-sources"
         fi
 
+        # Note: we install cffi from source in order to ensure that it is linked with the system ffi library.
+        # This in turn relies on the libffi-dev package being installed on the system, avoiding errors such as
+        # "it seems that the version of the libffi library seen at runtime is different from the 'ffi.h' file seen at compile-time"
         $pip_command install --upgrade pip
+        $pip_command install --force-reinstall --no-binary :all: cffi
         $pip_command install pytest pytest-cov build
         if [ -f ${{ inputs.requirements_path }} ]; then
           $pip_command install -r ${{ inputs.requirements_path }}


### PR DESCRIPTION
Added comments to clarify cffi installation process and dependencies.

### Description
Install cffi from source at startup in order to ensure that it is built with the system ffi library.

This in turn relies on the libffi-dev package being installed on the system, and thereby avoids errors such as "it seems that the version of the libffi library seen at runtime is different from the 'ffi.h' file seen at compile-time"


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
