### PR TITLE
chore: newer uv

### DIFF
--- a/.github/workflows/qa-pytest-pyproject.yml
+++ b/.github/workflows/qa-pytest-pyproject.yml
@@ -63,9 +63,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-        with:
-          version: 0.7.19
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Install dependencies
         working-directory: ${{ inputs.working-directory }}
         if: ${{ inputs.install-dependencies }}


### PR DESCRIPTION
### Description

Seems the uv version is pinned to 0.7.19 in the action, which is too old for e.g. `exclude-newer` or other features. Anyway, if one really wants 0.7.19, it can always be set via config

> If you do not specify a version, this action will look for a required-version in a uv.toml or pyproject.toml file in the repository root. If none is found, the latest version will be installed.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
