### PR TITLE
Replace deprecated pre-commit/action with inline steps

### DIFF
--- a/.github/workflows/qa-precommit-run.yml
+++ b/.github/workflows/qa-precommit-run.yml
@@ -27,7 +27,14 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
+    - name: Install pre-commit
+      run: python -m pip install pre-commit
+    - name: Cache pre-commit environments
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Run pre-commit hooks
-      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      run: pre-commit run --show-diff-on-failure --color=always --all-files
       env:
         SKIP: ${{ inputs.skip-hooks }}


### PR DESCRIPTION
### Description

Replaces deprecated pre-commit actions with pip install pre-commit. This makes sure we are not using deprecated Node 20 in the action.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
