### PR TITLE
Fix extra_deps retrieval in cd-pypi.yml

### DIFF
--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -88,7 +88,7 @@ jobs:
           if [ -f "setup.py" ]; then
             if [ -f "pyproject.toml" ] ; then
               # we need to install eg setuptools_scm to correctly determine version later
-              extra_deps=$(python -c 'import tomllib; print(" ".join(f"{e}" for e in tomllib.load(open("pyproject.toml", "rb"))["build-system"]["requires"]))')
+              extra_deps=$(python -c 'import tomllib; print(" ".join(f"{e}" for e in tomllib.load(open("pyproject.toml", "rb")).get("build-system", {}).get("requires", "")))')
               pip install --upgrade $extra_deps
             fi
             version=$(python setup.py --version)


### PR DESCRIPTION
Update the way extra dependencies are retrieved from pyproject.toml to handle missing keys gracefully.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
